### PR TITLE
chore: Update script permissions for correct user ownership

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -19,6 +19,7 @@ sudo rm -rf /var/lib/apt/lists/*
 
 sudo chown vscode:vscode /workspaces
 
+sudo chown -R vscode:vscode scripts
 chmod +x scripts/*.sh
 
 # Clone `nyanten`.


### PR DESCRIPTION
`chmod +x scripts/*.sh` が権限の問題で失敗するのを修正する。