### PR TITLE
refactor: Make each function in build-map generics to standardize duplicated code

### DIFF
--- a/src/bin/build_map/main.rs
+++ b/src/bin/build_map/main.rs
@@ -21,7 +21,7 @@ use xiangting::standard::zipai_table::ZIPAI_SIZE;
 type Map = Vec<MapValue>;
 
 fn pack_replacement_numbers<const N: usize>(hand: &[u8; N]) -> MapValue {
-    assert!([9, 7, 2].contains(&N));
+    debug_assert!([9, 7, 2].contains(&N));
     const MAX_REPLACEMENT_NUMBER: u8 = 9;
 
     let mut pack = [0u32; 5];
@@ -86,7 +86,7 @@ fn pack_replacement_numbers<const N: usize>(hand: &[u8; N]) -> MapValue {
 }
 
 fn create_entry<const N: usize>(hand: &[u8; N], map: &mut Map) {
-    assert!([9, 7, 2].contains(&N));
+    debug_assert!([9, 7, 2].contains(&N));
 
     let h = match N {
         9 => hash_shupai(hand),
@@ -122,7 +122,7 @@ fn build_map<const N: usize>(hand: &mut [u8; N], i: usize, n: usize, map: &mut M
 }
 
 fn dump_map<const N: usize>(map: &Map, map_path: &Path) -> io::Result<()> {
-    assert!([9, 7, 2].contains(&N));
+    debug_assert!([9, 7, 2].contains(&N));
 
     let file = File::create(map_path)?;
     let mut w = BufWriter::new(file);

--- a/src/bin/build_map/main.rs
+++ b/src/bin/build_map/main.rs
@@ -29,11 +29,10 @@ fn pack_replacement_numbers<const N: usize>(hand: &[u8; N]) -> MapValue {
         for num_meld in 0..=4 {
             let (replacement_number, necessary_tiles) = match N {
                 9 => {
-                    let mut hand9 = [0u8; 9];
-                    hand9.copy_from_slice(&hand[0..9]);
+                    let hand9 = hand.first_chunk::<9>().unwrap();
                     const INITIAL_WINNING_HAND: [u8; 9] = [0u8; 9];
                     get_shupai_replacement_number(
-                        &hand9,
+                        hand9,
                         num_meld,
                         num_pair,
                         0,
@@ -47,11 +46,10 @@ fn pack_replacement_numbers<const N: usize>(hand: &[u8; N]) -> MapValue {
                     )
                 }
                 7 => {
-                    let mut hand7 = [0u8; 7];
-                    hand7.copy_from_slice(&hand[0..7]);
+                    let hand7 = hand.first_chunk::<7>().unwrap();
                     const INITIAL_WINNING_HAND: [u8; 7] = [0u8; 7];
                     get_zipai_replacement_number(
-                        &hand7,
+                        hand7,
                         num_meld,
                         num_pair,
                         0,


### PR DESCRIPTION
build-map の各関数をジェネリクスにして重複しているコードを共通化する。
また、assert! を debug_assert! に変更する。