### PR TITLE
chore: Bump up version to v2.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xiangting"
 description = "A library for calculation of deficiency number (a.k.a. xiangting number, 向聴数)."
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Apricot S."]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
バージョン番号を上げるのを忘れていたため対応する。