### PR TITLE
refactor: 0 pair 0 meld's replacement number and necessary tiles fixed to 0

### DIFF
--- a/src/standard/calculate.rs
+++ b/src/standard/calculate.rs
@@ -32,7 +32,7 @@ type UnpackedNumbers = [u8; 10];
 fn unpack(pack: &MapValue) -> Unpacked {
     (
         [
-            (pack[0] & 0x0F) as u8,
+            0u8,
             (pack[1] & 0x0F) as u8,
             (pack[2] & 0x0F) as u8,
             (pack[3] & 0x0F) as u8,
@@ -44,7 +44,7 @@ fn unpack(pack: &MapValue) -> Unpacked {
             ((pack[4] >> 16) & 0x0F) as u8,
         ],
         [
-            ((pack[0] >> 4) & 0x01FF) as u16,
+            0u16,
             ((pack[1] >> 4) & 0x01FF) as u16,
             ((pack[2] >> 4) & 0x01FF) as u16,
             ((pack[3] >> 4) & 0x01FF) as u16,


### PR DESCRIPTION
0 雀頭 0 面子の部分置換数は常に 0、有効牌はなしとなる。
そのため、pack した置換数と有効牌を unpack する際 pack[0] を参照する必要はなく、常に 0 としてよい。
これにより実行時の計算時間がわずかに減少する。
Criterion.rs のベンチマークでは変更前と比べて 0.6 % ~ 6.3 % 減少している。