### PR TITLE
refactor: Remove dependence on cxx-build except during verification tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ mt19937 = "2.0.1"
 rand = "0.8.5"
 
 [build-dependencies]
-cxx-build = "1.0.128"
+cxx-build = { version = "1.0.128", optional = true }
 
 [features]
 build-file = []
 build-map = ["build-file"]
-correctness = []
+correctness = ["dep:cxx-build"]
 
 [[bin]]
 name = "build-table"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/Apricot-S/xiangting
 
+#[cfg(feature = "correctness")]
 fn main() {
     if std::env::var("CARGO_FEATURE_CORRECTNESS").is_ok() {
         cxx_build::bridge("tests/nyanten.rs")
@@ -16,3 +17,6 @@ fn main() {
         println!("cargo:rerun-if-changed=tests/correctness.rs");
     }
 }
+
+#[cfg(not(feature = "correctness"))]
+fn main() {}


### PR DESCRIPTION
cxx-build は Nyanten との比較検証テストのときのみ必要だったが、常に依存関係に含まれていた。
optional と feature を指定することにより、検証テスト以外では依存関係に含まれないようにする。