### PR TITLE
refactor: Simplify shisanyao::calculate_replacement_number() for clarity

### DIFF
--- a/src/shisanyao.rs
+++ b/src/shisanyao.rs
@@ -11,19 +11,15 @@ pub(super) fn calculate_replacement_number(bingpai: &Bingpai, num_bingpai: u8) -
     }
 
     const YAOJIUPAI_INDICES: [usize; 13] = [0, 8, 9, 17, 18, 26, 27, 28, 29, 30, 31, 32, 33];
-    let (num_kinds, has_jiangpai) =
-        YAOJIUPAI_INDICES
-            .iter()
-            .fold((0, false), |(mut num_kinds, mut has_jiangpai), &index| {
-                let count = bingpai[index];
-                if count >= 1 {
-                    num_kinds += 1;
-                    has_jiangpai |= count >= 2;
-                }
-                (num_kinds, has_jiangpai)
-            });
+    let (num_kinds, has_jiangpai) = YAOJIUPAI_INDICES
+        .iter()
+        .map(|&i| bingpai[i])
+        .filter(|&count| count > 0)
+        .fold((0, false), |(num_kinds, has_jiangpai), count| {
+            (num_kinds + 1, has_jiangpai || count >= 2)
+        });
 
-    14 - num_kinds - (if has_jiangpai { 1 } else { 0 })
+    14 - num_kinds - (has_jiangpai as u8)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
国士無双のシャンテン数計算の実装をより簡潔にする

ベンチマークでは変更前後でほぼ速度は変わらなかった (一般形の計算時間が大きいと思われる)