### PR TITLE
refactor: Use `iter().min()` instead of `std::cmp::min()` for clarity

### DIFF
--- a/src/standard/calculate.rs
+++ b/src/standard/calculate.rs
@@ -104,7 +104,11 @@ fn add_partial_replacement_number(lhs: &mut UnpackedNumbers, rhs: &UnpackedNumbe
     for i in (6..10).rev() {
         let mut r = min(lhs[i] + rhs[0], lhs[0] + rhs[i]);
         for j in 5..i {
-            r = min(r, min(lhs[j] + rhs[i - j], lhs[i - j] + rhs[j]));
+            r = [r, lhs[j] + rhs[i - j], lhs[i - j] + rhs[j]]
+                .iter()
+                .min()
+                .unwrap()
+                .clone();
         }
         lhs[i] = r;
     }


### PR DESCRIPTION
読みやすさ向上のため `std::cmp::min()` を 2 回使用する代わりに `iter().min()` を使用する。
速度はほぼ同等であることをベンチマークで確認済み。
`iter()` ではなく `into_iter()` を使用すると 7~8 % 実行時間が長くなる (遅くなる) ことも確認した。

- `std::cmp::min()`
```
test result: ok. 0 passed; 0 failed; 109 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/bench.rs (target/release/deps/bench-704f06e6734c0224)
xiangting/Normal        time:   [84.387 ns 84.495 ns 84.609 ns]
                        change: [+1.1459% +1.4932% +1.8271%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1245 outliers among 10000 measurements (12.45%)
  22 (0.22%) low mild
  550 (5.50%) high mild
  673 (6.73%) high severe

xiangting/Half Flush    time:   [84.765 ns 84.868 ns 84.977 ns]
                        change: [+0.1965% +0.4760% +0.7572%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 900 outliers among 10000 measurements (9.00%)
  21 (0.21%) low mild
  450 (4.50%) high mild
  429 (4.29%) high severe

xiangting/Full Flush    time:   [83.762 ns 83.883 ns 84.010 ns]
                        change: [-0.1358% +0.1139% +0.3584%] (p = 0.37 > 0.05)
                        No change in performance detected.
Found 603 outliers among 10000 measurements (6.03%)
  313 (3.13%) high mild
  290 (2.90%) high severe

xiangting/Non-Simple    time:   [83.651 ns 83.743 ns 83.841 ns]
                        change: [+0.0279% +0.2809% +0.5299%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 800 outliers among 10000 measurements (8.00%)
  2 (0.02%) low mild
  385 (3.85%) high mild
  413 (4.13%) high severe

     Running benches/random_hand.rs (target/release/deps/random_hand-60a7b060c9cfc9aa)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
- `iter().min()`
```
test result: ok. 0 passed; 0 failed; 109 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/bench.rs (target/release/deps/bench-704f06e6734c0224)
xiangting/Normal        time:   [84.416 ns 84.503 ns 84.596 ns]
                        change: [-1.1711% -0.8460% -0.5265%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1003 outliers among 10000 measurements (10.03%)
  5 (0.05%) low mild
  559 (5.59%) high mild
  439 (4.39%) high severe

xiangting/Half Flush    time:   [85.203 ns 85.312 ns 85.429 ns]
                        change: [-0.3589% -0.0756% +0.2142%] (p = 0.60 > 0.05)
                        No change in performance detected.
Found 807 outliers among 10000 measurements (8.07%)
  27 (0.27%) low mild
  452 (4.52%) high mild
  328 (3.28%) high severe

xiangting/Full Flush    time:   [84.179 ns 84.300 ns 84.426 ns]
                        change: [+0.3303% +0.5853% +0.8140%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 570 outliers among 10000 measurements (5.70%)
  325 (3.25%) high mild
  245 (2.45%) high severe

xiangting/Non-Simple    time:   [83.501 ns 83.592 ns 83.689 ns]
                        change: [-0.3357% -0.0683% +0.1980%] (p = 0.61 > 0.05)
                        No change in performance detected.
Found 886 outliers among 10000 measurements (8.86%)
  104 (1.04%) low mild
  392 (3.92%) high mild
  390 (3.90%) high severe

     Running benches/random_hand.rs (target/release/deps/random_hand-60a7b060c9cfc9aa)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
- `into_iter().min()`
```
test result: ok. 0 passed; 0 failed; 109 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/bench.rs (target/release/deps/bench-704f06e6734c0224)
xiangting/Normal        time:   [90.403 ns 90.518 ns 90.638 ns]
                        change: [+6.9430% +7.2095% +7.4712%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1306 outliers among 10000 measurements (13.06%)
  158 (1.58%) low mild
  487 (4.87%) high mild
  661 (6.61%) high severe

xiangting/Half Flush    time:   [91.461 ns 91.563 ns 91.673 ns]
                        change: [+7.8993% +8.2075% +8.5196%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 888 outliers among 10000 measurements (8.88%)
  49 (0.49%) low mild
  373 (3.73%) high mild
  466 (4.66%) high severe

xiangting/Full Flush    time:   [89.832 ns 89.953 ns 90.080 ns]
                        change: [+7.3699% +7.6870% +8.0060%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 721 outliers among 10000 measurements (7.21%)
  373 (3.73%) high mild
  348 (3.48%) high severe

xiangting/Non-Simple    time:   [91.153 ns 91.675 ns 92.322 ns]
                        change: [+7.7947% +8.1371% +8.4974%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 502 outliers among 10000 measurements (5.02%)
  4 (0.04%) low mild
  314 (3.14%) high mild
  184 (1.84%) high severe

     Running benches/random_hand.rs (target/release/deps/random_hand-60a7b060c9cfc9aa)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```