### PR TITLE
fix: Fix wrong loop range in DP

### DIFF
--- a/src/standard/calculate.rs
+++ b/src/standard/calculate.rs
@@ -101,7 +101,7 @@ fn modify_numbers(entry: Unpacked, four_tiles: u16) -> UnpackedNumbers {
 }
 
 fn add_partial_replacement_number(lhs: &mut UnpackedNumbers, rhs: &UnpackedNumbers) {
-    for i in (6..10).rev() {
+    for i in (5..10).rev() {
         let mut r = min(lhs[i] + rhs[0], lhs[0] + rhs[i]);
         for j in 5..i {
             r = [r, lhs[j] + rhs[i - j], lhs[i - j] + rhs[j]]
@@ -113,7 +113,7 @@ fn add_partial_replacement_number(lhs: &mut UnpackedNumbers, rhs: &UnpackedNumbe
         lhs[i] = r;
     }
 
-    for i in (1..6).rev() {
+    for i in (0..5).rev() {
         let mut r = lhs[i] + rhs[0];
         for j in 0..i {
             r = min(r, lhs[j] + rhs[i - j]);


### PR DESCRIPTION
動的計画法の計算部分で for ループ範囲が誤っていたのを修正する。
この修正により計算時間が 15~20 % 程度削減される。
二回目の for ループで内側の for ループの回数が変わるためだと思われる。

修正後のベンチマーク結果
```
test result: ok. 0 passed; 0 failed; 109 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/bench.rs (target/release/deps/bench-704f06e6734c0224)
xiangting/Normal        time:   [70.309 ns 70.402 ns 70.504 ns]
                        change: [-16.917% -16.694% -16.468%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 578 outliers among 10000 measurements (5.78%)
  295 (2.95%) high mild
  283 (2.83%) high severe

xiangting/Half Flush    time:   [69.078 ns 69.160 ns 69.244 ns]
                        change: [-21.156% -20.398% -19.732%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 597 outliers among 10000 measurements (5.97%)
  6 (0.06%) low mild
  294 (2.94%) high mild
  297 (2.97%) high severe

xiangting/Full Flush    time:   [66.594 ns 66.683 ns 66.776 ns]
                        change: [-27.094% -26.792% -26.500%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 735 outliers among 10000 measurements (7.35%)
  357 (3.57%) high mild
  378 (3.78%) high severe

xiangting/Non-Simple    time:   [67.737 ns 67.812 ns 67.892 ns]
                        change: [-19.519% -19.301% -19.075%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 625 outliers among 10000 measurements (6.25%)
  350 (3.50%) high mild
  275 (2.75%) high severe

     Running benches/random_hand.rs (target/release/deps/random_hand-60a7b060c9cfc9aa)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```