### PR TITLE
docs: Add API reference link and update `cargo add` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation:
 ## Installation
 
 ```sh
-cargo add --git https://github.com/Apricot-S/xiangting.git
+cargo add xiangting
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ However, it introduces the following additional features:
 Documentation:
 
 - [API reference (main branch)](https://Apricot-S.github.io/xiangting/xiangting)
+- [API reference (docs.rs)](https://docs.rs/xiangting)
 
 ## Installation
 


### PR DESCRIPTION
crates.io に登録するので README を更新する。
- API リファレンスに docs.rs のリンクを追加する。
- `cargo add` を git リポジトリではなく crates.io から取得するように変更する。