### PR TITLE
refactor: Measure the execution time of `build-map` within the program so as not to include the build time

### DIFF
--- a/scripts/build_map.sh
+++ b/scripts/build_map.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 
-start_time=$(date +%s)
-
 cargo run --bin build-map --release --features build-map -- \
     src/standard/shupai_map.rs \
     src/standard/zipai_map.rs \
     src/standard/wanzi_19_map.rs
-
-end_time=$(date +%s)
-execution_time=$((end_time - start_time))
-
-echo "Execution time: $execution_time seconds"

--- a/src/bin/build_map/main.rs
+++ b/src/bin/build_map/main.rs
@@ -175,6 +175,8 @@ fn dump_map<const N: usize>(map: &Map, map_path: &Path) -> io::Result<()> {
 }
 
 fn main() {
+    let start = std::time::Instant::now();
+
     let args: Vec<String> = env::args().collect();
     if args.len() != 4 {
         eprintln!(
@@ -214,4 +216,7 @@ fn main() {
 
         dump_map::<2>(&wanzi_19_map, wanzi_19_map_path).expect("Failed to dump wanzi 19 map");
     }
+
+    let elapsed_time = start.elapsed();
+    println!("elapsed time: {:?}", elapsed_time);
 }


### PR DESCRIPTION
ちなみに実行時間は `elapsed time: 4.174605248s` 程度である。