### PR TITLE
refactor: Allow `clippy::too_many_arguments` in build-map

### DIFF
--- a/src/bin/build_map/replacement_number.rs
+++ b/src/bin/build_map/replacement_number.rs
@@ -6,6 +6,8 @@
 // https://github.com/gimite/MjaiClients/blob/master/src/org/ymatsux/mjai/client/ShantensuUtil.java
 // https://github.com/gimite/mjai-manue/blob/master/coffee/shanten_analysis.coffee
 
+#![allow(clippy::too_many_arguments)]
+
 use std::cmp::Ordering;
 
 const NUM_SHUPAI_IDS: usize = 9;


### PR DESCRIPTION
T/O