### PR TITLE
chore: Add "riichi" to keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.85"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/Apricot-S/xiangting"
-keywords = ["mahjong", "shanten", "xiangting"]
+keywords = ["mahjong", "riichi", "shanten", "xiangting"]
 categories = ["algorithms"]
 
 [lib]


### PR DESCRIPTION
他の麻雀関係の crate は "riichi" もキーワードに含んでいることが多いため合わせて追加する。