### PR TITLE
refactor: hide Shoupai's fields and add accessors

### DIFF
--- a/src/qiduizi/necessary_tiles.rs
+++ b/src/qiduizi/necessary_tiles.rs
@@ -6,11 +6,11 @@ use crate::shoupai::{Shoupai, Shoupai3Player};
 use crate::tile::TileFlags;
 
 pub(in super::super) fn calculate_necessary_tiles(shoupai: &Shoupai) -> (u8, TileFlags) {
-    if shoupai.num_required_bingpai_mianzi < 4 {
+    if shoupai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
 
-    let (num_duizi, num_kinds, waits, wait_candidates) = shoupai.bingpai.iter().enumerate().fold(
+    let (num_duizi, num_kinds, waits, wait_candidates) = shoupai.bingpai().iter().enumerate().fold(
         (0, 0, 0u64, 0u64),
         |(num_duizi, num_kinds, waits, wait_candidates), (i, &count)| match count {
             0 => (num_duizi, num_kinds, waits, wait_candidates | (1 << i)),
@@ -34,12 +34,12 @@ pub(in super::super) fn calculate_necessary_tiles(shoupai: &Shoupai) -> (u8, Til
 pub(in super::super) fn calculate_necessary_tiles_3_player(
     shoupai: &Shoupai3Player,
 ) -> (u8, TileFlags) {
-    if shoupai.num_required_bingpai_mianzi < 4 {
+    if shoupai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
 
     let (num_duizi, num_kinds, waits, wait_candidates) = shoupai
-        .bingpai
+        .bingpai()
         .iter()
         .enumerate()
         .filter(|(i, _)| !matches!(i, 1..=7))

--- a/src/qiduizi/replacement_number.rs
+++ b/src/qiduizi/replacement_number.rs
@@ -5,12 +5,12 @@
 use crate::shoupai::Shoupai;
 
 pub(in super::super) fn calculate_replacement_number(shoupai: &Shoupai) -> u8 {
-    if shoupai.num_required_bingpai_mianzi < 4 {
+    if shoupai.num_required_bingpai_mianzi() < 4 {
         return u8::MAX;
     }
 
     let (num_kinds, num_duizi) = shoupai
-        .bingpai
+        .bingpai()
         .iter()
         .filter(|&&count| count > 0)
         .fold((0, 0), |(num_kinds, num_duizi), &count| {

--- a/src/qiduizi/unnecessary_tiles.rs
+++ b/src/qiduizi/unnecessary_tiles.rs
@@ -6,12 +6,12 @@ use crate::shoupai::{Shoupai, Shoupai3Player};
 use crate::tile::TileFlags;
 
 pub(in super::super) fn calculate_unnecessary_tiles(shoupai: &Shoupai) -> (u8, TileFlags) {
-    if shoupai.num_required_bingpai_mianzi < 4 {
+    if shoupai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
 
     let (num_duizi, num_kinds, discards, discard_candidates) =
-        shoupai.bingpai.iter().enumerate().fold(
+        shoupai.bingpai().iter().enumerate().fold(
             (0, 0, 0u64, 0u64),
             |(num_duizi, num_kinds, discards, discard_candidates), (i, &count)| match count {
                 0 => (num_duizi, num_kinds, discards, discard_candidates),
@@ -46,12 +46,12 @@ pub(in super::super) fn calculate_unnecessary_tiles(shoupai: &Shoupai) -> (u8, T
 pub(in super::super) fn calculate_unnecessary_tiles_3_player(
     shoupai: &Shoupai3Player,
 ) -> (u8, TileFlags) {
-    if shoupai.num_required_bingpai_mianzi < 4 {
+    if shoupai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
 
     let (num_duizi, num_kinds, discards, discard_candidates) = shoupai
-        .bingpai
+        .bingpai()
         .iter()
         .enumerate()
         .filter(|(i, _)| !matches!(i, 1..=7))

--- a/src/shisanyao/necessary_tiles.rs
+++ b/src/shisanyao/necessary_tiles.rs
@@ -7,13 +7,13 @@ use crate::shoupai::Shoupai;
 use crate::tile::TileFlags;
 
 pub(in super::super) fn calculate_necessary_tiles(shoupai: &Shoupai) -> (u8, TileFlags) {
-    if shoupai.num_required_bingpai_mianzi < 4 {
+    if shoupai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
 
     let (num_kinds, has_jiangpai, waits, wait_candidates) = YAOJIUPAI_INDICES
         .iter()
-        .map(|&i| (i, &shoupai.bingpai[i]))
+        .map(|&i| (i, &shoupai.bingpai()[i]))
         .fold(
             (0, false, 0u64, 0u64),
             |(num_kinds, has_jiangpai, waits, wait_candidates), (i, &count)| match count {

--- a/src/shisanyao/replacement_number.rs
+++ b/src/shisanyao/replacement_number.rs
@@ -6,13 +6,13 @@ use super::common::YAOJIUPAI_INDICES;
 use crate::shoupai::Shoupai;
 
 pub(in super::super) fn calculate_replacement_number(shoupai: &Shoupai) -> u8 {
-    if shoupai.num_required_bingpai_mianzi < 4 {
+    if shoupai.num_required_bingpai_mianzi() < 4 {
         return u8::MAX;
     }
 
     let (num_kinds, has_jiangpai) = YAOJIUPAI_INDICES
         .iter()
-        .map(|&i| &shoupai.bingpai[i])
+        .map(|&i| &shoupai.bingpai()[i])
         .filter(|&&count| count > 0)
         .fold((0, false), |(num_kinds, has_jiangpai), &count| {
             (num_kinds + 1, has_jiangpai || count >= 2)

--- a/src/shisanyao/unnecessary_tiles.rs
+++ b/src/shisanyao/unnecessary_tiles.rs
@@ -7,13 +7,13 @@ use crate::shoupai::Shoupai;
 use crate::tile::TileFlags;
 
 pub(in super::super) fn calculate_unnecessary_tiles(shoupai: &Shoupai) -> (u8, TileFlags) {
-    if shoupai.num_required_bingpai_mianzi < 4 {
+    if shoupai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
 
     let (num_kinds, num_jiangpai, discards, discard_candidates) = YAOJIUPAI_INDICES
         .iter()
-        .map(|&i| (i, &shoupai.bingpai[i]))
+        .map(|&i| (i, &shoupai.bingpai()[i]))
         .fold(
             (0, 0, 0u64, 0u64),
             |(num_kinds, num_jiangpai, discards, discard_candidates), (i, &count)| match count {
@@ -40,7 +40,7 @@ pub(in super::super) fn calculate_unnecessary_tiles(shoupai: &Shoupai) -> (u8, T
     ];
     let discards = DUANYAOJIUPAI_INDICES
         .iter()
-        .map(|&i| (i, &shoupai.bingpai[i]))
+        .map(|&i| (i, &shoupai.bingpai()[i]))
         .filter(|(_, count)| **count > 0)
         .fold(discards, |d, (i, _)| d | (1 << i));
 

--- a/src/shoupai.rs
+++ b/src/shoupai.rs
@@ -81,9 +81,9 @@ impl FuluMianziListExt for FuluMianziList {
 }
 
 pub(crate) struct Shoupai<'a> {
-    pub(crate) bingpai: &'a TileCounts,
-    pub(crate) tile_counts: Option<TileCounts>,
-    pub(crate) num_required_bingpai_mianzi: u8,
+    bingpai: &'a TileCounts,
+    tile_counts: Option<TileCounts>,
+    num_required_bingpai_mianzi: u8,
 }
 
 impl<'a> Shoupai<'a> {
@@ -111,12 +111,30 @@ impl<'a> Shoupai<'a> {
             num_required_bingpai_mianzi,
         })
     }
+
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn bingpai(&self) -> &'a TileCounts {
+        self.bingpai
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn tile_counts(&self) -> Option<&TileCounts> {
+        self.tile_counts.as_ref()
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn num_required_bingpai_mianzi(&self) -> u8 {
+        self.num_required_bingpai_mianzi
+    }
 }
 
 pub(crate) struct Shoupai3Player<'a> {
-    pub(crate) bingpai: &'a TileCounts,
-    pub(crate) tile_counts: Option<TileCounts>,
-    pub(crate) num_required_bingpai_mianzi: u8,
+    bingpai: &'a TileCounts,
+    tile_counts: Option<TileCounts>,
+    num_required_bingpai_mianzi: u8,
 }
 
 impl<'a> Shoupai3Player<'a> {
@@ -143,6 +161,24 @@ impl<'a> Shoupai3Player<'a> {
             tile_counts,
             num_required_bingpai_mianzi,
         })
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn bingpai(&self) -> &'a TileCounts {
+        self.bingpai
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn tile_counts(&self) -> Option<&TileCounts> {
+        self.tile_counts.as_ref()
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn num_required_bingpai_mianzi(&self) -> u8 {
+        self.num_required_bingpai_mianzi
     }
 }
 

--- a/src/standard/replacement_number.rs
+++ b/src/standard/replacement_number.rs
@@ -73,20 +73,20 @@ fn update_dp(lhs: &mut UnpackedNumbers, rhs: &UnpackedNumbers) {
 }
 
 pub(in super::super) fn calculate_replacement_number(shoupai: &Shoupai) -> u8 {
-    let h0 = hash_shupai(&shoupai.bingpai[0..9]);
-    let h1 = hash_shupai(&shoupai.bingpai[9..18]);
-    let h2 = hash_shupai(&shoupai.bingpai[18..27]);
-    let h3 = hash_zipai(&shoupai.bingpai[27..34]);
+    let h0 = hash_shupai(&shoupai.bingpai()[0..9]);
+    let h1 = hash_shupai(&shoupai.bingpai()[9..18]);
+    let h2 = hash_shupai(&shoupai.bingpai()[18..27]);
+    let h3 = hash_zipai(&shoupai.bingpai()[27..34]);
 
     let unpacked0 = unpack(&SHUPAI_MAP[h0]);
     let unpacked1 = unpack(&SHUPAI_MAP[h1]);
     let unpacked2 = unpack(&SHUPAI_MAP[h2]);
     let unpacked3 = unpack(&ZIPAI_MAP[h3]);
 
-    let (mut entry0, entry1, entry2, entry3) = match shoupai.tile_counts {
+    let (mut entry0, entry1, entry2, entry3) = match shoupai.tile_counts() {
         None => (unpacked0.0, unpacked1.0, unpacked2.0, unpacked3.0),
         Some(s) => {
-            let four_tiles = count_4_tiles_in_shoupai(&s);
+            let four_tiles = count_4_tiles_in_shoupai(s);
             let (four_tiles_m, four_tiles_p, four_tiles_s, four_tiles_z) = split_flags(four_tiles);
 
             (
@@ -102,24 +102,24 @@ pub(in super::super) fn calculate_replacement_number(shoupai: &Shoupai) -> u8 {
     update_dp(&mut entry0, &entry2);
     update_dp(&mut entry0, &entry3);
 
-    entry0[5 + shoupai.num_required_bingpai_mianzi as usize]
+    entry0[5 + shoupai.num_required_bingpai_mianzi() as usize]
 }
 
 pub(in super::super) fn calculate_replacement_number_3_player(shoupai: &Shoupai3Player) -> u8 {
-    let h0 = hash_19m(&shoupai.bingpai[0..9]);
-    let h1 = hash_shupai(&shoupai.bingpai[9..18]);
-    let h2 = hash_shupai(&shoupai.bingpai[18..27]);
-    let h3 = hash_zipai(&shoupai.bingpai[27..34]);
+    let h0 = hash_19m(&shoupai.bingpai()[0..9]);
+    let h1 = hash_shupai(&shoupai.bingpai()[9..18]);
+    let h2 = hash_shupai(&shoupai.bingpai()[18..27]);
+    let h3 = hash_zipai(&shoupai.bingpai()[27..34]);
 
     let unpacked0 = unpack(&WANZI_19_MAP[h0]);
     let unpacked1 = unpack(&SHUPAI_MAP[h1]);
     let unpacked2 = unpack(&SHUPAI_MAP[h2]);
     let unpacked3 = unpack(&ZIPAI_MAP[h3]);
 
-    let (mut entry0, entry1, entry2, entry3) = match shoupai.tile_counts {
+    let (mut entry0, entry1, entry2, entry3) = match shoupai.tile_counts() {
         None => (unpacked0.0, unpacked1.0, unpacked2.0, unpacked3.0),
         Some(s) => {
-            let four_tiles = count_4_tiles_in_shoupai(&s);
+            let four_tiles = count_4_tiles_in_shoupai(s);
             let (four_tiles_m, four_tiles_p, four_tiles_s, four_tiles_z) = split_flags(four_tiles);
 
             (
@@ -135,7 +135,7 @@ pub(in super::super) fn calculate_replacement_number_3_player(shoupai: &Shoupai3
     update_dp(&mut entry0, &entry2);
     update_dp(&mut entry0, &entry3);
 
-    entry0[5 + shoupai.num_required_bingpai_mianzi as usize]
+    entry0[5 + shoupai.num_required_bingpai_mianzi() as usize]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
フィールドをプライベートにしてアクセサ経由での参照にすることで型の不変条件を保証する。