### PR TITLE
feat: Change the error hierarchy

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 Apricot S.
+// SPDX-License-Identifier: MIT
+// This file is part of https://github.com/Apricot-S/xiangting
+
+use crate::shoupai::ShoupaiError;
+use thiserror::Error;
+
+/// Errors that can occur when calculating the deficiency number for a hand.
+#[derive(Debug, Error)]
+pub enum XiangtingError {
+    /// The hand is invalid.
+    #[error("hand is invalid: {0}")]
+    InvalidShoupai(#[from] ShoupaiError),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ mod bingpai;
 #[cfg(not(feature = "build-file"))]
 mod constants;
 #[cfg(not(feature = "build-file"))]
+mod error;
+#[cfg(not(feature = "build-file"))]
 mod fulu_mianzi;
 #[cfg(not(feature = "build-file"))]
 mod necessary_tiles;
@@ -61,13 +63,15 @@ mod test_utils;
 #[cfg(not(feature = "build-file"))]
 pub use bingpai::BingpaiError;
 #[cfg(not(feature = "build-file"))]
+pub use error::XiangtingError;
+#[cfg(not(feature = "build-file"))]
 pub use fulu_mianzi::{ClaimedTilePosition, FuluMianzi, FuluMianziError};
 #[cfg(not(feature = "build-file"))]
 pub use necessary_tiles::{calculate_necessary_tiles, calculate_necessary_tiles_3_player};
 #[cfg(not(feature = "build-file"))]
 pub use replacement_number::{calculate_replacement_number, calculate_replacement_number_3_player};
 #[cfg(not(feature = "build-file"))]
-pub use shoupai::{ShoupaiError, XiangtingError};
+pub use shoupai::ShoupaiError;
 #[cfg(not(feature = "build-file"))]
 pub use tile::{Tile, TileCounts, TileFlags, TileFlagsExt};
 #[cfg(not(feature = "build-file"))]

--- a/src/necessary_tiles.rs
+++ b/src/necessary_tiles.rs
@@ -4,8 +4,9 @@
 
 use super::qiduizi;
 use super::shisanyao;
+use crate::error::XiangtingError;
 use crate::fulu_mianzi::FuluMianzi;
-use crate::shoupai::{Shoupai, Shoupai3Player, XiangtingError};
+use crate::shoupai::{Shoupai, Shoupai3Player};
 use crate::tile::{TileCounts, TileFlags};
 use std::cmp::Ordering;
 

--- a/src/replacement_number.rs
+++ b/src/replacement_number.rs
@@ -5,8 +5,9 @@
 use super::qiduizi;
 use super::shisanyao;
 use super::standard;
+use crate::error::XiangtingError;
 use crate::fulu_mianzi::FuluMianzi;
-use crate::shoupai::{Shoupai, Shoupai3Player, XiangtingError};
+use crate::shoupai::{Shoupai, Shoupai3Player};
 use crate::tile::TileCounts;
 
 /// Calculates the replacement number (= xiangting number + 1) for a given hand.
@@ -192,7 +193,7 @@ mod tests {
     use super::*;
     use crate::bingpai::BingpaiError;
     use crate::fulu_mianzi::{ClaimedTilePosition, FuluMianziError};
-    use crate::shoupai::{ShoupaiError, XiangtingError};
+    use crate::shoupai::ShoupaiError;
     use crate::test_utils::FromTileCode;
 
     #[test]
@@ -222,8 +223,8 @@ mod tests {
         let replacement_number = calculate_replacement_number(&bingpai, None);
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidBingpai(
-                BingpaiError::InvalidTileCount(0)
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidBingpai(BingpaiError::InvalidTileCount(0))
             ))
         ));
     }
@@ -248,8 +249,8 @@ mod tests {
         let replacement_number = calculate_replacement_number(&bingpai, None);
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidBingpai(
-                BingpaiError::InvalidTileCount(3)
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidBingpai(BingpaiError::InvalidTileCount(3))
             ))
         ));
     }
@@ -260,9 +261,9 @@ mod tests {
         let replacement_number = calculate_replacement_number(&bingpai, None);
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidBingpai(BingpaiError::TooManyTiles(
-                15
-            )))
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidBingpai(BingpaiError::TooManyTiles(15))
+            ))
         ));
     }
 
@@ -272,8 +273,8 @@ mod tests {
         let replacement_number = calculate_replacement_number(&bingpai, None);
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidBingpai(
-                BingpaiError::TooManyCopies { tile: 0, count: 5 }
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidBingpai(BingpaiError::TooManyCopies { tile: 0, count: 5 })
             ))
         ));
     }
@@ -285,8 +286,8 @@ mod tests {
         let replacement_number = calculate_replacement_number(&bingpai, Some(&fulu_mianzi_list));
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidFuluMianzi(
-                FuluMianziError::IndexOutOfRange(34)
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidFuluMianzi(FuluMianziError::IndexOutOfRange(34))
             ))
         ));
     }
@@ -298,8 +299,8 @@ mod tests {
         let replacement_number = calculate_replacement_number(&bingpai, Some(&fulu_mianzi_list));
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidFuluMianzi(
-                FuluMianziError::ShunziWithZipai(27)
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidFuluMianzi(FuluMianziError::ShunziWithZipai(27))
             ))
         ));
     }
@@ -311,8 +312,11 @@ mod tests {
         let replacement_number = calculate_replacement_number(&bingpai, Some(&fulu_mianzi_list));
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidFuluMianzi(
-                FuluMianziError::InvalidShunziCombination(0, ClaimedTilePosition::Middle)
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidFuluMianzi(FuluMianziError::InvalidShunziCombination(
+                    0,
+                    ClaimedTilePosition::Middle
+                ))
             ))
         ));
     }
@@ -370,8 +374,8 @@ mod tests {
         let replacement_number = calculate_replacement_number_3_player(&bingpai, None);
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidBingpai(
-                BingpaiError::InvalidTileFor3Player(1)
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidBingpai(BingpaiError::InvalidTileFor3Player(1))
             ))
         ));
     }
@@ -384,10 +388,9 @@ mod tests {
             calculate_replacement_number_3_player(&bingpai, Some(&fulu_mianzi_list));
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidFuluMianzi(
-                FuluMianziError::InvalidFuluMianziFor3Player(FuluMianzi::Shunzi(
-                    9,
-                    ClaimedTilePosition::Low
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidFuluMianzi(FuluMianziError::InvalidFuluMianziFor3Player(
+                    FuluMianzi::Shunzi(9, ClaimedTilePosition::Low)
                 ))
             ))
         ));
@@ -401,8 +404,10 @@ mod tests {
             calculate_replacement_number_3_player(&bingpai, Some(&fulu_mianzi_list));
         assert!(matches!(
             replacement_number,
-            Err(XiangtingError::InvalidFuluMianzi(
-                FuluMianziError::InvalidFuluMianziFor3Player(FuluMianzi::Kezi(1))
+            Err(XiangtingError::InvalidShoupai(
+                ShoupaiError::InvalidFuluMianzi(FuluMianziError::InvalidFuluMianziFor3Player(
+                    FuluMianzi::Kezi(1)
+                ))
             ))
         ));
     }

--- a/src/shoupai.rs
+++ b/src/shoupai.rs
@@ -11,6 +11,12 @@ use thiserror::Error;
 /// Errors that occur when an invalid hand (手牌) is provided.
 #[derive(Debug, Error)]
 pub enum ShoupaiError {
+    /// The hand contains an invalid pure hand.
+    #[error("hand contains an invalid pure hand: {0}")]
+    InvalidBingpai(#[from] BingpaiError),
+    /// The hand contains an invalid meld.
+    #[error("hand contains an invalid meld: {0}")]
+    InvalidFuluMianzi(#[from] FuluMianziError),
     /// The number of melds in the hand exceeds the allowed maximum.
     #[error("the number of melds must be at most {max}, but was {count}")]
     TooManyFuluMianzi {
@@ -27,20 +33,6 @@ pub enum ShoupaiError {
         /// The actual number of copies found in the hand.
         count: u8,
     },
-}
-
-/// Errors that can occur when calculating the deficiency number for a hand.
-#[derive(Debug, Error)]
-pub enum XiangtingError {
-    /// The hand contains an invalid pure hand.
-    #[error("hand contains an invalid pure hand: {0}")]
-    InvalidBingpai(#[from] BingpaiError),
-    /// The hand contains an invalid meld.
-    #[error("hand contains an invalid meld: {0}")]
-    InvalidFuluMianzi(#[from] FuluMianziError),
-    /// The hand contains an invalid combination of pure hand and melds.
-    #[error("hand contains an invalid combination of pure hand and melds: {0}")]
-    InvalidShoupai(#[from] ShoupaiError),
 }
 
 type FuluMianziList = [FuluMianzi];
@@ -90,7 +82,7 @@ impl<'a> Shoupai<'a> {
     pub(crate) fn new(
         bingpai: &'a TileCounts,
         fulu_mianzi_list: Option<&[FuluMianzi]>,
-    ) -> Result<Self, XiangtingError> {
+    ) -> Result<Self, ShoupaiError> {
         let num_bingpai = bingpai.count()?;
         let num_required_bingpai_mianzi = num_bingpai / 3;
 
@@ -141,7 +133,7 @@ impl<'a> Shoupai3Player<'a> {
     pub(crate) fn new(
         bingpai: &'a TileCounts,
         fulu_mianzi_list: Option<&[FuluMianzi]>,
-    ) -> Result<Self, XiangtingError> {
+    ) -> Result<Self, ShoupaiError> {
         let num_bingpai = bingpai.count_3_player()?;
         let num_required_bingpai_mianzi = num_bingpai / 3;
 

--- a/src/unnecessary_tiles.rs
+++ b/src/unnecessary_tiles.rs
@@ -4,8 +4,9 @@
 
 use super::qiduizi;
 use super::shisanyao;
+use crate::error::XiangtingError;
 use crate::fulu_mianzi::FuluMianzi;
-use crate::shoupai::{Shoupai, Shoupai3Player, XiangtingError};
+use crate::shoupai::{Shoupai, Shoupai3Player};
 use crate::tile::{TileCounts, TileFlags};
 use std::cmp::Ordering;
 


### PR DESCRIPTION
breaking changes

v3 のときのエラー階層に戻す。
現在開発中の点数計算ライブラリ hule とエラー階層を合わせる (hule では手牌以外のエラーも発生する)。