### PR TITLE
refactor: Improve DP efficiency

### DIFF
--- a/src/standard/necessary_tiles.rs
+++ b/src/standard/necessary_tiles.rs
@@ -76,12 +76,19 @@ fn update_dp(lhs: &mut Entry, rhs: &Entry) {
         // ```
         // let mut number = lhs.numbers[i] + rhs.numbers[0];
         // let mut tiles = lhs.tiles[i] | rhs.tiles[0];
+        // update_min(
+        //     &mut number,
+        //     &mut tiles,
+        //     lhs.numbers[0] + rhs.numbers[i],
+        //     rhs.tiles[0] | rhs.tiles[i],
+        // );
         // ```
-        // However, since rhs[0] is always 0, the calculation can be omitted.
+        // However, since lhs[0] and rhs[0] are always 0, the calculation can be omitted.
         let mut number = lhs.numbers[i];
         let mut tiles = lhs.tiles[i];
+        update_min(&mut number, &mut tiles, rhs.numbers[i], rhs.tiles[i]);
 
-        for j in 0..i {
+        for j in 1..i {
             update_min(
                 &mut number,
                 &mut tiles,

--- a/src/standard/replacement_number.rs
+++ b/src/standard/replacement_number.rs
@@ -71,11 +71,11 @@ fn update_dp(lhs: &mut UnpackedNumbers, rhs: &UnpackedNumbers) {
     for i in (1..5).rev() {
         // The original expression is
         // ```
-        // let mut r = lhs[i] + rhs[0];
+        // let mut r = min(lhs[i] + rhs[0], lhs[0] + rhs[i]);
         // ```
-        // However, since rhs[0] is always 0, the calculation can be omitted.
-        let mut r = lhs[i];
-        for j in 0..i {
+        // However, since lhs[0] and rhs[0] are always 0, the calculation can be omitted.
+        let mut r = min(lhs[i], rhs[i]);
+        for j in 1..i {
             r = min(r, lhs[j] + rhs[i - j]);
         }
         lhs[i] = r;


### PR DESCRIPTION
雀頭なしの方のループを効率化する。
lhs[0] の無駄な参照を省略した。