### PR TITLE
refactor: Use "3p" internally instead of "3Player"/"3_player" (API unaffected)

### DIFF
--- a/src/bingpai.rs
+++ b/src/bingpai.rs
@@ -30,7 +30,7 @@ pub enum BingpaiError {
 
 pub(crate) trait TileCountsExt {
     fn count(&self) -> Result<u8, BingpaiError>;
-    fn count_3_player(&self) -> Result<u8, BingpaiError>;
+    fn count_3p(&self) -> Result<u8, BingpaiError>;
 }
 
 impl TileCountsExt for TileCounts {
@@ -52,7 +52,7 @@ impl TileCountsExt for TileCounts {
         }
     }
 
-    fn count_3_player(&self) -> Result<u8, BingpaiError> {
+    fn count_3p(&self) -> Result<u8, BingpaiError> {
         if let Some(i) = self[1..8].iter().position(|&t| t > 0) {
             return Err(BingpaiError::InvalidTileFor3Player((i + 1) as u8));
         }

--- a/src/fulu_mianzi.rs
+++ b/src/fulu_mianzi.rs
@@ -115,7 +115,7 @@ impl FuluMianzi {
         Ok(())
     }
 
-    pub(crate) fn validate_3_player(&self) -> Result<(), FuluMianziError> {
+    pub(crate) fn validate_3p(&self) -> Result<(), FuluMianziError> {
         match self {
             FuluMianzi::Shunzi(..) => {
                 Err(FuluMianziError::InvalidFuluMianziFor3Player(self.clone()))

--- a/src/necessary_tiles.rs
+++ b/src/necessary_tiles.rs
@@ -50,9 +50,9 @@ pub fn calculate_necessary_tiles_3_player(
     let shoupai_3p = Shoupai3p::new(bingpai, fulu_mianzi_list)?;
 
     let (mut replacement_number, mut necessary_tiles) =
-        standard::calculate_necessary_tiles_3_player(&shoupai_3p);
+        standard::calculate_necessary_tiles_3p(&shoupai_3p);
 
-    let (r1, n1) = qiduizi::calculate_necessary_tiles_3_player(&shoupai_3p);
+    let (r1, n1) = qiduizi::calculate_necessary_tiles_3p(&shoupai_3p);
     match r1.cmp(&replacement_number) {
         Ordering::Less => {
             replacement_number = r1;

--- a/src/qiduizi.rs
+++ b/src/qiduizi.rs
@@ -6,8 +6,6 @@ mod necessary_tiles;
 mod replacement_number;
 mod unnecessary_tiles;
 
-pub(super) use necessary_tiles::{calculate_necessary_tiles, calculate_necessary_tiles_3_player};
+pub(super) use necessary_tiles::{calculate_necessary_tiles, calculate_necessary_tiles_3p};
 pub(super) use replacement_number::calculate_replacement_number;
-pub(super) use unnecessary_tiles::{
-    calculate_unnecessary_tiles, calculate_unnecessary_tiles_3_player,
-};
+pub(super) use unnecessary_tiles::{calculate_unnecessary_tiles, calculate_unnecessary_tiles_3p};

--- a/src/qiduizi/necessary_tiles.rs
+++ b/src/qiduizi/necessary_tiles.rs
@@ -31,7 +31,7 @@ pub(in super::super) fn calculate_necessary_tiles(shoupai: &Shoupai) -> (u8, Til
     (replacement_number, necessary_tiles)
 }
 
-pub(in super::super) fn calculate_necessary_tiles_3_player(shoupai: &Shoupai3p) -> (u8, TileFlags) {
+pub(in super::super) fn calculate_necessary_tiles_3p(shoupai: &Shoupai3p) -> (u8, TileFlags) {
     if shoupai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
@@ -138,10 +138,10 @@ mod tests {
     }
 
     #[test]
-    fn calculate_necessary_tiles_3_player_with_quadruple() {
+    fn calculate_necessary_tiles_3p_with_quadruple() {
         let bingpai = TileCounts::from_code("1199m288p55s1111z");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3_player(&shoupai);
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&shoupai);
         assert_eq!(replacement_number, 3);
         assert_eq!(
             necessary_tiles,

--- a/src/qiduizi/unnecessary_tiles.rs
+++ b/src/qiduizi/unnecessary_tiles.rs
@@ -43,9 +43,7 @@ pub(in super::super) fn calculate_unnecessary_tiles(shoupai: &Shoupai) -> (u8, T
     (replacement_number, unnecessary_tiles)
 }
 
-pub(in super::super) fn calculate_unnecessary_tiles_3_player(
-    shoupai: &Shoupai3p,
-) -> (u8, TileFlags) {
+pub(in super::super) fn calculate_unnecessary_tiles_3p(shoupai: &Shoupai3p) -> (u8, TileFlags) {
     if shoupai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
@@ -157,11 +155,10 @@ mod tests {
     }
 
     #[test]
-    fn calculate_unnecessary_tiles_3_player_with_quadruple() {
+    fn calculate_unnecessary_tiles_3p_with_quadruple() {
         let bingpai = TileCounts::from_code("1199m288p55s1111z");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let (replacement_number, unnecessary_tiles) =
-            calculate_unnecessary_tiles_3_player(&shoupai);
+        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles_3p(&shoupai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1z"));
     }

--- a/src/replacement_number.rs
+++ b/src/replacement_number.rs
@@ -178,7 +178,7 @@ pub fn calculate_replacement_number_3_player(
 ) -> Result<u8, XiangtingError> {
     let shoupai_3p = Shoupai3p::new(bingpai, fulu_mianzi_list)?;
 
-    let r0 = standard::calculate_replacement_number_3_player(&shoupai_3p);
+    let r0 = standard::calculate_replacement_number_3p(&shoupai_3p);
 
     let shoupai = shoupai_3p.into();
 

--- a/src/shoupai.rs
+++ b/src/shoupai.rs
@@ -134,7 +134,7 @@ impl<'a> Shoupai3p<'a> {
         bingpai: &'a TileCounts,
         fulu_mianzi_list: Option<&[FuluMianzi]>,
     ) -> Result<Self, ShoupaiError> {
-        let num_bingpai = bingpai.count_3_player()?;
+        let num_bingpai = bingpai.count_3p()?;
         let num_required_bingpai_mianzi = num_bingpai / 3;
 
         let max_num_fulu = MAX_NUM_MIANZI - num_required_bingpai_mianzi;
@@ -142,7 +142,7 @@ impl<'a> Shoupai3p<'a> {
         validate_num_fulu(num_fulu, max_num_fulu)?;
 
         fulu_mianzi_list
-            .map(|fl| fl.iter().try_for_each(|f| f.validate_3_player()))
+            .map(|fl| fl.iter().try_for_each(|f| f.validate_3p()))
             .transpose()?;
 
         let tile_counts = get_tile_counts(bingpai, fulu_mianzi_list);

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -26,10 +26,10 @@ mod zipai_map;
 mod zipai_table;
 
 #[cfg(not(feature = "build-file"))]
-pub(super) use necessary_tiles::{calculate_necessary_tiles, calculate_necessary_tiles_3_player};
+pub(super) use necessary_tiles::{calculate_necessary_tiles, calculate_necessary_tiles_3p};
 #[cfg(not(feature = "build-file"))]
 pub(super) use replacement_number::{
-    calculate_replacement_number, calculate_replacement_number_3_player,
+    calculate_replacement_number, calculate_replacement_number_3p,
 };
 
 #[cfg(feature = "build-map")]

--- a/src/standard/necessary_tiles.rs
+++ b/src/standard/necessary_tiles.rs
@@ -158,7 +158,7 @@ pub(in super::super) fn calculate_necessary_tiles(shoupai: &Shoupai) -> (u8, Til
     (entry0.numbers[n], entry0.tiles[n])
 }
 
-pub(in super::super) fn calculate_necessary_tiles_3_player(shoupai: &Shoupai3p) -> (u8, TileFlags) {
+pub(in super::super) fn calculate_necessary_tiles_3p(shoupai: &Shoupai3p) -> (u8, TileFlags) {
     let hash_m = hash_19m(&shoupai.bingpai()[0..9]);
     let hash_p = hash_shupai(&shoupai.bingpai()[9..18]);
     let hash_s = hash_shupai(&shoupai.bingpai()[18..27]);
@@ -693,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn calculate_necessary_tiles_different_3_player_and_4_player() {
+    fn calculate_necessary_tiles_different_3p_and_4p() {
         let bingpai = TileCounts::from_code("1111m111122233z");
         let shoupai = Shoupai::new(&bingpai, None).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&shoupai);
@@ -702,10 +702,10 @@ mod tests {
     }
 
     #[test]
-    fn calculate_necessary_tiles_3_player_different_3_player_and_4_player() {
+    fn calculate_necessary_tiles_3p_different_3p_and_4p() {
         let bingpai = TileCounts::from_code("1111m111122233z");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3_player(&shoupai);
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&shoupai);
         assert_eq!(replacement_number, 3);
         assert_eq!(
             necessary_tiles,
@@ -714,10 +714,10 @@ mod tests {
     }
 
     #[test]
-    fn calculate_necessary_tiles_3_player_4_19m_1() {
+    fn calculate_necessary_tiles_3p_4_19m_1() {
         let bingpai = TileCounts::from_code("1111m");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3_player(&shoupai);
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&shoupai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
             necessary_tiles,
@@ -726,10 +726,10 @@ mod tests {
     }
 
     #[test]
-    fn calculate_necessary_tiles_3_player_4_19m_2() {
+    fn calculate_necessary_tiles_3p_4_19m_2() {
         let bingpai = TileCounts::from_code("1111m123p");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3_player(&shoupai);
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&shoupai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
             necessary_tiles,
@@ -738,10 +738,10 @@ mod tests {
     }
 
     #[test]
-    fn calculate_necessary_tiles_3_player_4_19m_3() {
+    fn calculate_necessary_tiles_3p_4_19m_3() {
         let bingpai = TileCounts::from_code("11119999m");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3_player(&shoupai);
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&shoupai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
             necessary_tiles,

--- a/src/standard/replacement_number.rs
+++ b/src/standard/replacement_number.rs
@@ -135,7 +135,7 @@ pub(in super::super) fn calculate_replacement_number(shoupai: &Shoupai) -> u8 {
     entry0[5 + shoupai.num_required_bingpai_mianzi() as usize]
 }
 
-pub(in super::super) fn calculate_replacement_number_3_player(shoupai: &Shoupai3p) -> u8 {
+pub(in super::super) fn calculate_replacement_number_3p(shoupai: &Shoupai3p) -> u8 {
     let hash_m = hash_19m(&shoupai.bingpai()[0..9]);
     let hash_p = hash_shupai(&shoupai.bingpai()[9..18]);
     let hash_s = hash_shupai(&shoupai.bingpai()[18..27]);
@@ -592,7 +592,7 @@ mod tests {
     }
 
     #[test]
-    fn calculate_replacement_number_different_3_player_and_4_player() {
+    fn calculate_replacement_number_different_3p_and_4p() {
         let bingpai = TileCounts::from_code("1111m111122233z");
         let shoupai = Shoupai::new(&bingpai, None).unwrap();
         let replacement_number = calculate_replacement_number(&shoupai);
@@ -600,34 +600,34 @@ mod tests {
     }
 
     #[test]
-    fn calculate_replacement_number_3_player_different_3_player_and_4_player() {
+    fn calculate_replacement_number_3p_different_3p_and_4p() {
         let bingpai = TileCounts::from_code("1111m111122233z");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let replacement_number = calculate_replacement_number_3_player(&shoupai);
+        let replacement_number = calculate_replacement_number_3p(&shoupai);
         assert_eq!(replacement_number, 3);
     }
 
     #[test]
-    fn calculate_replacement_number_3_player_4_19m_1() {
+    fn calculate_replacement_number_3p_4_19m_1() {
         let bingpai = TileCounts::from_code("1111m");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let replacement_number = calculate_replacement_number_3_player(&shoupai);
+        let replacement_number = calculate_replacement_number_3p(&shoupai);
         assert_eq!(replacement_number, 2);
     }
 
     #[test]
-    fn calculate_replacement_number_3_player_4_19m_2() {
+    fn calculate_replacement_number_3p_4_19m_2() {
         let bingpai = TileCounts::from_code("1111m123p");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let replacement_number = calculate_replacement_number_3_player(&shoupai);
+        let replacement_number = calculate_replacement_number_3p(&shoupai);
         assert_eq!(replacement_number, 2);
     }
 
     #[test]
-    fn calculate_replacement_number_3_player_4_19m_3() {
+    fn calculate_replacement_number_3p_4_19m_3() {
         let bingpai = TileCounts::from_code("11119999m");
         let shoupai = Shoupai3p::new(&bingpai, None).unwrap();
-        let replacement_number = calculate_replacement_number_3_player(&shoupai);
+        let replacement_number = calculate_replacement_number_3p(&shoupai);
         assert_eq!(replacement_number, 2);
     }
 }

--- a/src/unnecessary_tiles.rs
+++ b/src/unnecessary_tiles.rs
@@ -49,7 +49,7 @@ pub fn calculate_unnecessary_tiles_3_player(
 
     let (mut replacement_number, mut unnecessary_tiles) = (u8::MAX, 0u64);
 
-    let (r1, u1) = qiduizi::calculate_unnecessary_tiles_3_player(&shoupai_3p);
+    let (r1, u1) = qiduizi::calculate_unnecessary_tiles_3p(&shoupai_3p);
     match r1.cmp(&replacement_number) {
         Ordering::Less => {
             replacement_number = r1;


### PR DESCRIPTION
ライブラリ内部で "3Player" および "3_player" となっている部分を "3p" に変更する。
公開 API は変更しない (公開 API は別の PR で "three player" に変更予定)。