### PR TITLE
breaking change: Public API rename "3Player"/"3_player" → "ThreePlayer"/"three_player"

### DIFF
--- a/src/bingpai.rs
+++ b/src/bingpai.rs
@@ -23,9 +23,9 @@ pub enum BingpaiError {
     /// Total tile count in the pure hand is not of the form 3n+1 or 3n+2.
     #[error("total tile count must be a multiple of 3 plus 1 or 2 but was {0}")]
     InvalidTileCount(u8),
-    /// The pure hand contains tiles that are not used in 3-player mahjong (2m-8m).
-    #[error("tile {0} cannot be used in 3-player mahjong")]
-    InvalidTileFor3Player(Tile),
+    /// The pure hand contains tiles that are not used in three-player mahjong (2m-8m).
+    #[error("tile {0} cannot be used in three-player mahjong")]
+    InvalidTileForThreePlayer(Tile),
 }
 
 pub(crate) trait TileCountsExt {
@@ -54,7 +54,7 @@ impl TileCountsExt for TileCounts {
 
     fn count_3p(&self) -> Result<u8, BingpaiError> {
         if let Some(i) = self[1..8].iter().position(|&t| t > 0) {
-            return Err(BingpaiError::InvalidTileFor3Player((i + 1) as u8));
+            return Err(BingpaiError::InvalidTileForThreePlayer((i + 1) as u8));
         }
         self.count()
     }

--- a/src/fulu_mianzi.rs
+++ b/src/fulu_mianzi.rs
@@ -87,9 +87,9 @@ pub enum FuluMianziError {
     /// The tile and position combination cannot form a valid sequence.
     #[error("a sequence cannot be made with {0} and {1:?}")]
     InvalidShunziCombination(Tile, ClaimedTilePosition),
-    /// This meld cannot be used in 3-player mahjong (2m-8m or sequence).
-    #[error("{0:?} cannot be used in 3-player mahjong")]
-    InvalidFuluMianziFor3Player(FuluMianzi),
+    /// This meld cannot be used in three-player mahjong (2m-8m or sequence).
+    #[error("{0:?} cannot be used in three-player mahjong")]
+    InvalidFuluMianziForThreePlayer(FuluMianzi),
 }
 
 impl FuluMianzi {
@@ -117,12 +117,12 @@ impl FuluMianzi {
 
     pub(crate) fn validate_3p(&self) -> Result<(), FuluMianziError> {
         match self {
-            FuluMianzi::Shunzi(..) => {
-                Err(FuluMianziError::InvalidFuluMianziFor3Player(self.clone()))
-            }
-            FuluMianzi::Kezi(t) | FuluMianzi::Gangzi(t) if (1..8).contains(t) => {
-                Err(FuluMianziError::InvalidFuluMianziFor3Player(self.clone()))
-            }
+            FuluMianzi::Shunzi(..) => Err(FuluMianziError::InvalidFuluMianziForThreePlayer(
+                self.clone(),
+            )),
+            FuluMianzi::Kezi(t) | FuluMianzi::Gangzi(t) if (1..8).contains(t) => Err(
+                FuluMianziError::InvalidFuluMianziForThreePlayer(self.clone()),
+            ),
             _ => self.validate(),
         }
     }

--- a/src/necessary_tiles.rs
+++ b/src/necessary_tiles.rs
@@ -275,7 +275,7 @@ mod tests {
         assert!(matches!(
             replacement_number,
             Err(XiangtingError::Shoupai(ShoupaiError::Bingpai(
-                BingpaiError::InvalidTileFor3Player(1)
+                BingpaiError::InvalidTileForThreePlayer(1)
             )))
         ));
     }
@@ -289,7 +289,7 @@ mod tests {
         assert!(matches!(
             replacement_number,
             Err(XiangtingError::Shoupai(ShoupaiError::FuluMianzi(
-                FuluMianziError::InvalidFuluMianziFor3Player(FuluMianzi::Shunzi(
+                FuluMianziError::InvalidFuluMianziForThreePlayer(FuluMianzi::Shunzi(
                     9,
                     ClaimedTilePosition::Low
                 ))
@@ -306,7 +306,7 @@ mod tests {
         assert!(matches!(
             replacement_number,
             Err(XiangtingError::Shoupai(ShoupaiError::FuluMianzi(
-                FuluMianziError::InvalidFuluMianziFor3Player(FuluMianzi::Kezi(1))
+                FuluMianziError::InvalidFuluMianziForThreePlayer(FuluMianzi::Kezi(1))
             )))
         ));
     }

--- a/src/replacement_number.rs
+++ b/src/replacement_number.rs
@@ -11,7 +11,7 @@ use crate::shoupai::{Shoupai, Shoupai3p};
 use crate::tile::TileCounts;
 
 /// Calculates the replacement number (= xiangting number + 1) for a given hand.
-/// This function is for 4-player mahjong.
+/// This function is for four-player mahjong.
 ///
 /// In some rulesets, melded tiles are excluded when checking whether a hand contains
 /// four identical tiles. In others, melded tiles are included in the calculation.
@@ -98,7 +98,7 @@ pub fn calculate_replacement_number(
 }
 
 /// Calculates the replacement number (= xiangting number + 1) for a given hand.
-/// This function is for 3-player mahjong.
+/// This function is for three-player mahjong.
 ///
 /// Tiles from 2m (二萬) to 8m (八萬) are not used.
 /// In addition, melded sequences (明順子) are not allowed.
@@ -374,7 +374,7 @@ mod tests {
         assert!(matches!(
             replacement_number,
             Err(XiangtingError::Shoupai(ShoupaiError::Bingpai(
-                BingpaiError::InvalidTileFor3Player(1)
+                BingpaiError::InvalidTileForThreePlayer(1)
             )))
         ));
     }
@@ -388,7 +388,7 @@ mod tests {
         assert!(matches!(
             replacement_number,
             Err(XiangtingError::Shoupai(ShoupaiError::FuluMianzi(
-                FuluMianziError::InvalidFuluMianziFor3Player(FuluMianzi::Shunzi(
+                FuluMianziError::InvalidFuluMianziForThreePlayer(FuluMianzi::Shunzi(
                     9,
                     ClaimedTilePosition::Low
                 ))
@@ -405,7 +405,7 @@ mod tests {
         assert!(matches!(
             replacement_number,
             Err(XiangtingError::Shoupai(ShoupaiError::FuluMianzi(
-                FuluMianziError::InvalidFuluMianziFor3Player(FuluMianzi::Kezi(1))
+                FuluMianziError::InvalidFuluMianziForThreePlayer(FuluMianzi::Kezi(1))
             )))
         ));
     }


### PR DESCRIPTION
公開 API で "3Player" および "3_player" となっている部分を "ThreePlayer"/"three_player" に変更する。

ただし、関数は 4p/3p を統合予定なので変更しない。