### PR TITLE
refactor: Move constants into each module and delete constants.rs

### DIFF
--- a/src/bingpai.rs
+++ b/src/bingpai.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/Apricot-S/xiangting
 
-use crate::constants::{MAX_NUM_BINGPAI, MAX_TILE_COPIES};
 use crate::tile::{Tile, TileCounts};
 use thiserror::Error;
+
+const MAX_TILE_COPIES: u8 = 4;
+const MAX_NUM_BINGPAI: u8 = 14;
 
 /// Errors that occur when an invalid pure hand (純手牌) is provided.
 #[derive(Debug, Error)]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: 2024 Apricot S.
-// SPDX-License-Identifier: MIT
-// This file is part of https://github.com/Apricot-S/xiangting
-
-pub(crate) const MAX_TILE_COPIES: u8 = 4;
-pub(crate) const NUM_TILE_INDEX: usize = 3 * 9 + 4 + 3;
-pub(crate) const MAX_NUM_BINGPAI: u8 = 14;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,6 @@ mod bingpai;
 #[cfg(not(feature = "build-file"))]
 mod config;
 #[cfg(not(feature = "build-file"))]
-mod constants;
-#[cfg(not(feature = "build-file"))]
 mod error;
 #[cfg(not(feature = "build-file"))]
 mod necessary_tiles;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/Apricot-S/xiangting
 
-use crate::constants::NUM_TILE_INDEX;
+const NUM_TILE_INDEX: usize = 3 * 9 + 4 + 3;
 
 /// 牌: Tile.
 ///


### PR DESCRIPTION
定数はそれぞれ 1 ファイルでしか使用されていないので、当該ファイルに定義を移動する。