### PR TITLE
refactor: Simplify thread count parsing in correctness tests

### DIFF
--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -19,10 +19,8 @@ mod tests {
     fn verify_correctness<const N: usize>() -> bool {
         let num_threads = env::var("NUM_THREADS")
             .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(1)
-            .try_into()
-            .unwrap();
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(1);
 
         if NUM_HANDS[N - 1] % num_threads != 0 {
             panic!(


### PR DESCRIPTION
`usize` にパースしてから `try_into()` で `u64` に変換していたのを最初から `u64` にパースするように変更する。