### PR TITLE
test: Use pcg64_fast instead of mt19937

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ thiserror = "2.0.17"
 [dev-dependencies]
 criterion = "0.7.0"
 cxx = "1.0.186"
-mt19937 = "3.1.0"
 rand = "0.9.2"
+rand_pcg = "0.9.0"
 
 [build-dependencies]
 cxx-build = { version = "1.0.186", optional = true }

--- a/benches/random_hand.rs
+++ b/benches/random_hand.rs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/Apricot-S/xiangting
 
-use mt19937::MT19937;
 use rand::seq::{IndexedRandom, SliceRandom};
 use rand::{Rng, SeedableRng};
+use rand_pcg::Pcg64Mcg;
 
-pub fn create_rng() -> MT19937 {
-    let mut seed = mt19937::Seed::default();
-    seed.0.fill(42);
-    MT19937::from_seed(seed)
+pub fn create_rng() -> Pcg64Mcg {
+    Pcg64Mcg::seed_from_u64(42)
 }
 
 #[inline]


### PR DESCRIPTION
ベンチマークに使用している乱数生成器をより高速な pcg64_fast に変更する。