### PR TITLE
docs: Use "xiàngtīng" instead of "xiangting" in documents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xiangting"
-description = "A library for calculating the deficiency number (a.k.a. xiangting number, 向聴数)."
+description = "A library for calculating the deficiency number (a.k.a. xiàngtīng number, 向聴数)."
 version = "5.0.1"
 authors = ["Apricot S."]
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![API](https://docs.rs/xiangting/badge.svg)](https://docs.rs/xiangting)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Apricot-S/xiangting)
 
-A library for calculating the deficiency number (a.k.a. xiangting number, 向聴数).
+A library for calculating the deficiency number (a.k.a. xiàngtīng number, 向聴数).
 
 Documentation:
 
@@ -54,7 +54,7 @@ The correspondence between the index and the tile is shown in the table below.
 | ----- | --------- | ---------- | --------- | ---------- | ---------- | ---------- | -------- |
 | Tile  | East (1z) | South (2z) | West (3z) | North (4z) | White (5z) | Green (6z) | Red (7z) |
 
-Calculates the replacement number, which is equal to the deficiency number (a.k.a. xiangting number, 向聴数) + 1.
+Calculates the replacement number, which is equal to the deficiency number (a.k.a. xiàngtīng number, 向聴数) + 1.
 
 ```rust
 use xiangting::{PlayerCount, calculate_replacement_number};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![warn(missing_docs)]
 
-//! A library for calculating the deficiency number (a.k.a. xiangting number, 向聴数).
+//! A library for calculating the deficiency number (a.k.a. xiàngtīng number, 向聴数).
 //!
 //! # Example
 //!

--- a/src/necessary_tiles.rs
+++ b/src/necessary_tiles.rs
@@ -10,7 +10,7 @@ use crate::config::PlayerCount;
 use crate::tile::{TileCounts, TileFlags};
 use std::cmp::Ordering;
 
-/// Calculates the replacement number (= xiangting number + 1) and necessary tiles for a given hand.
+/// Calculates the replacement number (= xiàngtīng number + 1) and necessary tiles for a given hand.
 ///
 /// # Arguments
 ///

--- a/src/replacement_number.rs
+++ b/src/replacement_number.rs
@@ -9,7 +9,7 @@ use crate::bingpai::{Bingpai, Bingpai3p, BingpaiError};
 use crate::config::PlayerCount;
 use crate::tile::TileCounts;
 
-/// Calculates the replacement number (= xiangting number + 1) for a given hand.
+/// Calculates the replacement number (= xiàngtīng number + 1) for a given hand.
 ///
 /// # Arguments
 ///

--- a/src/unnecessary_tiles.rs
+++ b/src/unnecessary_tiles.rs
@@ -10,7 +10,7 @@ use crate::config::PlayerCount;
 use crate::tile::{TileCounts, TileFlags};
 use std::cmp::Ordering;
 
-/// Calculates the replacement number (= xiangting number + 1) and unnecessary tiles for a given hand.
+/// Calculates the replacement number (= xiàngtīng number + 1) and unnecessary tiles for a given hand.
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
T/O