### PR TITLE
chore: Remove build-essential

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -13,7 +13,7 @@ if [[ -t 1 ]] && type -t tput >/dev/null; then
 fi
 
 sudo apt-get update
-sudo apt-get install -y build-essential gnuplot
+sudo apt-get install -y gnuplot
 sudo apt-get clean
 sudo rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
cxx crate が不要になったため C++ のビルド用のツールも不要となる。