### PR TITLE
refactor: unify player-specific hand calculations

### DIFF
--- a/src/bingpai.rs
+++ b/src/bingpai.rs
@@ -3,19 +3,48 @@
 // This file is part of https://github.com/Apricot-S/xiangting
 
 use crate::tile::{Tile, TileCounts};
+use core::marker::PhantomData;
 use thiserror::Error;
 
 const MAX_TILE_COPIES: u8 = 4;
 const MAX_NUM_BINGPAI: u8 = 14;
 
-pub(crate) struct Bingpai<'a> {
-    tile_counts: &'a TileCounts,
-    num_required_bingpai_mianzi: u8,
+pub(crate) trait PlayerRule {
+    const IS_THREE_PLAYER: bool;
+
+    fn validate(tile_counts: &TileCounts) -> Result<(), BingpaiError>;
 }
 
-pub(crate) struct Bingpai3p<'a> {
+pub(crate) enum FourPlayer {}
+
+pub(crate) enum ThreePlayer {}
+
+impl PlayerRule for FourPlayer {
+    const IS_THREE_PLAYER: bool = false;
+
+    #[inline(always)]
+    fn validate(_tile_counts: &TileCounts) -> Result<(), BingpaiError> {
+        Ok(())
+    }
+}
+
+impl PlayerRule for ThreePlayer {
+    const IS_THREE_PLAYER: bool = true;
+
+    #[inline(always)]
+    fn validate(tile_counts: &TileCounts) -> Result<(), BingpaiError> {
+        if let Some(i) = tile_counts[1..8].iter().position(|&count| count != 0) {
+            return Err(BingpaiError::InvalidTileForThreePlayer((i + 1) as Tile));
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) struct Bingpai<'a, R: PlayerRule> {
     tile_counts: &'a TileCounts,
     num_required_bingpai_mianzi: u8,
+    rule: PhantomData<fn() -> R>,
 }
 
 /// Errors that occur when an invalid pure hand (純手牌) is provided.
@@ -42,7 +71,6 @@ pub enum BingpaiError {
 
 pub(crate) trait TileCountsExt {
     fn count(&self) -> Result<u8, BingpaiError>;
-    fn count_3p(&self) -> Result<u8, BingpaiError>;
 }
 
 impl TileCountsExt for TileCounts {
@@ -63,23 +91,18 @@ impl TileCountsExt for TileCounts {
             n => Ok(n),
         }
     }
-
-    fn count_3p(&self) -> Result<u8, BingpaiError> {
-        if let Some(i) = self[1..8].iter().position(|&t| t > 0) {
-            return Err(BingpaiError::InvalidTileForThreePlayer((i + 1) as u8));
-        }
-        self.count()
-    }
 }
 
-impl<'a> Bingpai<'a> {
+impl<'a, R: PlayerRule> Bingpai<'a, R> {
     pub(crate) fn new(tile_counts: &'a TileCounts) -> Result<Self, BingpaiError> {
+        R::validate(tile_counts)?;
         let num_bingpai = tile_counts.count()?;
         let num_required_bingpai_mianzi = num_bingpai / 3;
 
         Ok(Self {
             tile_counts,
             num_required_bingpai_mianzi,
+            rule: PhantomData,
         })
     }
 
@@ -93,38 +116,5 @@ impl<'a> Bingpai<'a> {
     #[must_use]
     pub(crate) fn num_required_bingpai_mianzi(&self) -> u8 {
         self.num_required_bingpai_mianzi
-    }
-}
-
-impl<'a> Bingpai3p<'a> {
-    pub(crate) fn new(tile_counts: &'a TileCounts) -> Result<Self, BingpaiError> {
-        let num_bingpai = tile_counts.count_3p()?;
-        let num_required_bingpai_mianzi = num_bingpai / 3;
-
-        Ok(Self {
-            tile_counts,
-            num_required_bingpai_mianzi,
-        })
-    }
-
-    #[inline(always)]
-    #[must_use]
-    pub(crate) fn tile_counts(&self) -> &'a TileCounts {
-        self.tile_counts
-    }
-
-    #[inline(always)]
-    #[must_use]
-    pub(crate) fn num_required_bingpai_mianzi(&self) -> u8 {
-        self.num_required_bingpai_mianzi
-    }
-}
-
-impl<'a> From<Bingpai3p<'a>> for Bingpai<'a> {
-    fn from(value: Bingpai3p<'a>) -> Self {
-        Self {
-            tile_counts: value.tile_counts,
-            num_required_bingpai_mianzi: value.num_required_bingpai_mianzi,
-        }
     }
 }

--- a/src/bingpai.rs
+++ b/src/bingpai.rs
@@ -33,7 +33,7 @@ impl PlayerRule for ThreePlayer {
 
     #[inline(always)]
     fn validate(tile_counts: &TileCounts) -> Result<(), BingpaiError> {
-        if let Some(i) = tile_counts[1..8].iter().position(|&count| count != 0) {
+        if let Some(i) = tile_counts[1..=7].iter().position(|&count| count != 0) {
             return Err(BingpaiError::InvalidTileForThreePlayer((i + 1) as Tile));
         }
 

--- a/src/necessary_tiles.rs
+++ b/src/necessary_tiles.rs
@@ -5,7 +5,7 @@
 use super::qiduizi;
 use super::shisanyao;
 use super::standard;
-use crate::bingpai::{Bingpai, Bingpai3p, BingpaiError};
+use crate::bingpai::{Bingpai, BingpaiError, FourPlayer, PlayerRule, ThreePlayer};
 use crate::config::PlayerCount;
 use crate::tile::{TileCounts, TileFlags};
 use core::cmp::Ordering;
@@ -74,13 +74,13 @@ pub fn calculate_necessary_tiles(
     player_count: PlayerCount,
 ) -> Result<(u8, TileFlags), BingpaiError> {
     match player_count {
-        PlayerCount::Four => calculate_necessary_tiles_4p(bingpai),
-        PlayerCount::Three => calculate_necessary_tiles_3p(bingpai),
+        PlayerCount::Four => calculate_for::<FourPlayer>(bingpai),
+        PlayerCount::Three => calculate_for::<ThreePlayer>(bingpai),
     }
 }
 
-fn calculate_necessary_tiles_4p(tile_counts: &TileCounts) -> Result<(u8, TileFlags), BingpaiError> {
-    let bingpai = Bingpai::new(tile_counts)?;
+fn calculate_for<R: PlayerRule>(tile_counts: &TileCounts) -> Result<(u8, TileFlags), BingpaiError> {
+    let bingpai = Bingpai::<R>::new(tile_counts)?;
 
     let (mut replacement_number, mut necessary_tiles) =
         standard::calculate_necessary_tiles(&bingpai);
@@ -94,37 +94,6 @@ fn calculate_necessary_tiles_4p(tile_counts: &TileCounts) -> Result<(u8, TileFla
         Ordering::Equal => necessary_tiles |= n1,
         Ordering::Greater => (),
     }
-
-    let (r2, n2) = shisanyao::calculate_necessary_tiles(&bingpai);
-    match r2.cmp(&replacement_number) {
-        Ordering::Less => {
-            replacement_number = r2;
-            necessary_tiles = n2;
-        }
-        Ordering::Equal => necessary_tiles |= n2,
-        Ordering::Greater => (),
-    }
-
-    Ok((replacement_number, necessary_tiles))
-}
-
-fn calculate_necessary_tiles_3p(tile_counts: &TileCounts) -> Result<(u8, TileFlags), BingpaiError> {
-    let bingpai_3p = Bingpai3p::new(tile_counts)?;
-
-    let (mut replacement_number, mut necessary_tiles) =
-        standard::calculate_necessary_tiles_3p(&bingpai_3p);
-
-    let (r1, n1) = qiduizi::calculate_necessary_tiles_3p(&bingpai_3p);
-    match r1.cmp(&replacement_number) {
-        Ordering::Less => {
-            replacement_number = r1;
-            necessary_tiles = n1;
-        }
-        Ordering::Equal => necessary_tiles |= n1,
-        Ordering::Greater => (),
-    }
-
-    let bingpai = bingpai_3p.into();
 
     let (r2, n2) = shisanyao::calculate_necessary_tiles(&bingpai);
     match r2.cmp(&replacement_number) {

--- a/src/qiduizi.rs
+++ b/src/qiduizi.rs
@@ -6,6 +6,6 @@ mod necessary_tiles;
 mod replacement_number;
 mod unnecessary_tiles;
 
-pub(super) use necessary_tiles::{calculate_necessary_tiles, calculate_necessary_tiles_3p};
+pub(super) use necessary_tiles::calculate_necessary_tiles;
 pub(super) use replacement_number::calculate_replacement_number;
-pub(super) use unnecessary_tiles::{calculate_unnecessary_tiles, calculate_unnecessary_tiles_3p};
+pub(super) use unnecessary_tiles::calculate_unnecessary_tiles;

--- a/src/qiduizi/necessary_tiles.rs
+++ b/src/qiduizi/necessary_tiles.rs
@@ -2,37 +2,12 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/Apricot-S/xiangting
 
-use crate::bingpai::{Bingpai, Bingpai3p};
+use crate::bingpai::{Bingpai, PlayerRule};
 use crate::tile::TileFlags;
 
-pub(in super::super) fn calculate_necessary_tiles(bingpai: &Bingpai) -> (u8, TileFlags) {
-    if bingpai.num_required_bingpai_mianzi() < 4 {
-        return (u8::MAX, 0);
-    }
-
-    let (num_duizi, num_kinds, waits, wait_candidates) =
-        bingpai.tile_counts().iter().enumerate().fold(
-            (0, 0, 0u64, 0u64),
-            |(num_duizi, num_kinds, waits, wait_candidates), (i, &count)| match count {
-                0 => (num_duizi, num_kinds, waits, wait_candidates | (1 << i)),
-                1 => (num_duizi, num_kinds + 1, waits | (1 << i), wait_candidates),
-                2..=4 => (num_duizi + 1, num_kinds + 1, waits, wait_candidates),
-                _ => unreachable!("tile {i} count must be 4 or less but was {count}"),
-            },
-        );
-
-    let replacement_number = 7 - num_duizi + 7u8.saturating_sub(num_kinds);
-
-    let necessary_tiles = if num_kinds < 7 {
-        waits | wait_candidates
-    } else {
-        waits
-    };
-
-    (replacement_number, necessary_tiles)
-}
-
-pub(in super::super) fn calculate_necessary_tiles_3p(bingpai: &Bingpai3p) -> (u8, TileFlags) {
+pub(in super::super) fn calculate_necessary_tiles<R: PlayerRule>(
+    bingpai: &Bingpai<R>,
+) -> (u8, TileFlags) {
     if bingpai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
@@ -41,7 +16,7 @@ pub(in super::super) fn calculate_necessary_tiles_3p(bingpai: &Bingpai3p) -> (u8
         .tile_counts()
         .iter()
         .enumerate()
-        .filter(|(i, _)| !matches!(i, 1..=7))
+        .filter(|(i, _)| !R::IS_THREE_PLAYER || !matches!(i, 1..=7))
         .fold(
             (0, 0, 0u64, 0u64),
             |(num_duizi, num_kinds, waits, wait_candidates), (i, &count)| match count {
@@ -66,13 +41,14 @@ pub(in super::super) fn calculate_necessary_tiles_3p(bingpai: &Bingpai3p) -> (u8
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::{FourPlayer, ThreePlayer};
     use crate::test_utils::FromTileCode;
     use crate::tile::{TileCounts, TileFlags};
 
     #[test]
     fn calculate_necessary_tiles_without_pair() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 7);
         assert_eq!(necessary_tiles, TileFlags::from_code("19m19p19s1234567z"));
@@ -81,7 +57,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_with_quadruple() {
         let tile_counts = TileCounts::from_code("1188m288p55s1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(
@@ -93,7 +69,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_with_triplet() {
         let tile_counts = TileCounts::from_code("1188m2388p55s111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(necessary_tiles, TileFlags::from_code("23p"));
@@ -102,7 +78,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_with_2_triplets() {
         let tile_counts = TileCounts::from_code("1188m288p555s111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(
@@ -114,7 +90,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_tenpai() {
         let tile_counts = TileCounts::from_code("1188m288p55s1177z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(necessary_tiles, TileFlags::from_code("2p"));
@@ -123,7 +99,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_win() {
         let tile_counts = TileCounts::from_code("1188m2288p55s1177z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 0);
         assert_eq!(necessary_tiles, TileFlags::from_code(""));
@@ -132,7 +108,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_incomplete_hand() {
         let tile_counts = TileCounts::from_code("1188m55s1122z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, u8::MAX);
         assert_eq!(necessary_tiles, TileFlags::from_code(""));
@@ -141,8 +117,8 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_3p_with_quadruple() {
         let tile_counts = TileCounts::from_code("288p5599s111122z");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(
             necessary_tiles,

--- a/src/qiduizi/replacement_number.rs
+++ b/src/qiduizi/replacement_number.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/Apricot-S/xiangting
 
-use crate::bingpai::Bingpai;
+use crate::bingpai::{Bingpai, PlayerRule};
 
-pub(in super::super) fn calculate_replacement_number(bingpai: &Bingpai) -> u8 {
+pub(in super::super) fn calculate_replacement_number<R: PlayerRule>(bingpai: &Bingpai<R>) -> u8 {
     if bingpai.num_required_bingpai_mianzi() < 4 {
         return u8::MAX;
     }
@@ -23,13 +23,14 @@ pub(in super::super) fn calculate_replacement_number(bingpai: &Bingpai) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::FourPlayer;
     use crate::test_utils::FromTileCode;
     use crate::tile::TileCounts;
 
     #[test]
     fn calculate_replacement_number_without_pair() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 7);
     }
@@ -37,7 +38,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_with_quadruple() {
         let tile_counts = TileCounts::from_code("1188m288p55s1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 3);
     }
@@ -45,7 +46,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_with_triplet() {
         let tile_counts = TileCounts::from_code("1188m2388p55s111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -53,7 +54,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_with_2_triplets() {
         let tile_counts = TileCounts::from_code("1188m288p555s111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 3);
     }
@@ -61,7 +62,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_tenpai() {
         let tile_counts = TileCounts::from_code("1188m288p55s1177z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 1);
     }
@@ -69,7 +70,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_win() {
         let tile_counts = TileCounts::from_code("1188m2288p55s1177z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 0);
     }
@@ -77,7 +78,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_incomplete_hand() {
         let tile_counts = TileCounts::from_code("1188m55s1122z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, u8::MAX);
     }

--- a/src/qiduizi/unnecessary_tiles.rs
+++ b/src/qiduizi/unnecessary_tiles.rs
@@ -2,48 +2,12 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/Apricot-S/xiangting
 
-use crate::bingpai::{Bingpai, Bingpai3p};
+use crate::bingpai::{Bingpai, PlayerRule};
 use crate::tile::TileFlags;
 
-pub(in super::super) fn calculate_unnecessary_tiles(bingpai: &Bingpai) -> (u8, TileFlags) {
-    if bingpai.num_required_bingpai_mianzi() < 4 {
-        return (u8::MAX, 0);
-    }
-
-    let (num_duizi, num_kinds, discards, discard_candidates) =
-        bingpai.tile_counts().iter().enumerate().fold(
-            (0, 0, 0u64, 0u64),
-            |(num_duizi, num_kinds, discards, discard_candidates), (i, &count)| match count {
-                0 => (num_duizi, num_kinds, discards, discard_candidates),
-                1 => (
-                    num_duizi,
-                    num_kinds + 1,
-                    discards,
-                    discard_candidates | (1 << i),
-                ),
-                2 => (num_duizi + 1, num_kinds + 1, discards, discard_candidates),
-                3..=4 => (
-                    num_duizi + 1,
-                    num_kinds + 1,
-                    discards | (1 << i),
-                    discard_candidates,
-                ),
-                _ => unreachable!("tile {i} count must be 4 or less but was {count}"),
-            },
-        );
-
-    let replacement_number = 7 - num_duizi + 7u8.saturating_sub(num_kinds);
-
-    let unnecessary_tiles = if num_kinds > 7 {
-        discards | discard_candidates
-    } else {
-        discards
-    };
-
-    (replacement_number, unnecessary_tiles)
-}
-
-pub(in super::super) fn calculate_unnecessary_tiles_3p(bingpai: &Bingpai3p) -> (u8, TileFlags) {
+pub(in super::super) fn calculate_unnecessary_tiles<R: PlayerRule>(
+    bingpai: &Bingpai<R>,
+) -> (u8, TileFlags) {
     if bingpai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
@@ -52,7 +16,7 @@ pub(in super::super) fn calculate_unnecessary_tiles_3p(bingpai: &Bingpai3p) -> (
         .tile_counts()
         .iter()
         .enumerate()
-        .filter(|(i, _)| !matches!(i, 1..=7))
+        .filter(|(i, _)| !R::IS_THREE_PLAYER || !matches!(i, 1..=7))
         .fold(
             (0, 0, 0u64, 0u64),
             |(num_duizi, num_kinds, discards, discard_candidates), (i, &count)| match count {
@@ -88,13 +52,14 @@ pub(in super::super) fn calculate_unnecessary_tiles_3p(bingpai: &Bingpai3p) -> (
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::{FourPlayer, ThreePlayer};
     use crate::test_utils::FromTileCode;
     use crate::tile::TileCounts;
 
     #[test]
     fn calculate_unnecessary_tiles_without_pair() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 7);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("19m19p19s1234567z"));
@@ -103,7 +68,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_with_quadruple() {
         let tile_counts = TileCounts::from_code("1188m288p55s1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1z"));
@@ -112,7 +77,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_with_triplet() {
         let tile_counts = TileCounts::from_code("1188m2388p55s111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1z"));
@@ -121,7 +86,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_with_2_triplets() {
         let tile_counts = TileCounts::from_code("1188m288p555s111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("5s1z"));
@@ -130,7 +95,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_tenpai() {
         let tile_counts = TileCounts::from_code("1188m288p55s1177z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -139,7 +104,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_win() {
         let tile_counts = TileCounts::from_code("1188m2288p55s1177z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 0);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -148,7 +113,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_incomplete_hand() {
         let tile_counts = TileCounts::from_code("1188m55s1122z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, u8::MAX);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -157,8 +122,8 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_3p_with_quadruple() {
         let tile_counts = TileCounts::from_code("1199m288p55s1111z");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1z"));
     }

--- a/src/replacement_number.rs
+++ b/src/replacement_number.rs
@@ -5,7 +5,7 @@
 use super::qiduizi;
 use super::shisanyao;
 use super::standard;
-use crate::bingpai::{Bingpai, Bingpai3p, BingpaiError};
+use crate::bingpai::{Bingpai, BingpaiError, FourPlayer, PlayerRule, ThreePlayer};
 use crate::config::PlayerCount;
 use crate::tile::TileCounts;
 
@@ -68,28 +68,15 @@ pub fn calculate_replacement_number(
     player_count: PlayerCount,
 ) -> Result<u8, BingpaiError> {
     match player_count {
-        PlayerCount::Four => calculate_replacement_number_4p(bingpai),
-        PlayerCount::Three => calculate_replacement_number_3p(bingpai),
+        PlayerCount::Four => calculate_for::<FourPlayer>(bingpai),
+        PlayerCount::Three => calculate_for::<ThreePlayer>(bingpai),
     }
 }
 
-fn calculate_replacement_number_4p(tile_counts: &TileCounts) -> Result<u8, BingpaiError> {
-    let bingpai = Bingpai::new(tile_counts)?;
+fn calculate_for<R: PlayerRule>(tile_counts: &TileCounts) -> Result<u8, BingpaiError> {
+    let bingpai = Bingpai::<R>::new(tile_counts)?;
 
     let r0 = standard::calculate_replacement_number(&bingpai);
-    let r1 = qiduizi::calculate_replacement_number(&bingpai);
-    let r2 = shisanyao::calculate_replacement_number(&bingpai);
-
-    Ok([r0, r1, r2].into_iter().min().unwrap())
-}
-
-fn calculate_replacement_number_3p(tile_counts: &TileCounts) -> Result<u8, BingpaiError> {
-    let bingpai_3p = Bingpai3p::new(tile_counts)?;
-
-    let r0 = standard::calculate_replacement_number_3p(&bingpai_3p);
-
-    let bingpai = bingpai_3p.into();
-
     let r1 = qiduizi::calculate_replacement_number(&bingpai);
     let r2 = shisanyao::calculate_replacement_number(&bingpai);
 

--- a/src/shisanyao/necessary_tiles.rs
+++ b/src/shisanyao/necessary_tiles.rs
@@ -3,10 +3,12 @@
 // This file is part of https://github.com/Apricot-S/xiangting
 
 use super::common::YAOJIUPAI_INDICES;
-use crate::bingpai::Bingpai;
+use crate::bingpai::{Bingpai, PlayerRule};
 use crate::tile::TileFlags;
 
-pub(in super::super) fn calculate_necessary_tiles(bingpai: &Bingpai) -> (u8, TileFlags) {
+pub(in super::super) fn calculate_necessary_tiles<R: PlayerRule>(
+    bingpai: &Bingpai<R>,
+) -> (u8, TileFlags) {
     if bingpai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
@@ -43,13 +45,14 @@ pub(in super::super) fn calculate_necessary_tiles(bingpai: &Bingpai) -> (u8, Til
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::FourPlayer;
     use crate::test_utils::FromTileCode;
     use crate::tile::{TileCounts, TileFlags};
 
     #[test]
     fn calculate_necessary_tiles_no_terminals_and_honors() {
         let tile_counts = TileCounts::from_code("23455m345p45678s");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 14);
         assert_eq!(necessary_tiles, TileFlags::from_code("19m19p19s1234567z"));
@@ -58,7 +61,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_without_pair() {
         let tile_counts = TileCounts::from_code("189m12p249s12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 5);
         assert_eq!(necessary_tiles, TileFlags::from_code("19m19p19s1234567z"));
@@ -67,7 +70,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_with_pair() {
         let tile_counts = TileCounts::from_code("119m12p299s12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 4);
         assert_eq!(necessary_tiles, TileFlags::from_code("9p1s67z"));
@@ -76,7 +79,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_tenpai() {
         let tile_counts = TileCounts::from_code("11m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(necessary_tiles, TileFlags::from_code("9m"));
@@ -85,7 +88,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_tenpai_13_wait() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(necessary_tiles, TileFlags::from_code("19m19p19s1234567z"));
@@ -94,7 +97,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_win() {
         let tile_counts = TileCounts::from_code("119m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 0);
         assert_eq!(necessary_tiles, TileFlags::from_code(""));
@@ -103,7 +106,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_incomplete_hand() {
         let tile_counts = TileCounts::from_code("19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, u8::MAX);
         assert_eq!(necessary_tiles, TileFlags::from_code(""));

--- a/src/shisanyao/replacement_number.rs
+++ b/src/shisanyao/replacement_number.rs
@@ -3,9 +3,9 @@
 // This file is part of https://github.com/Apricot-S/xiangting
 
 use super::common::YAOJIUPAI_INDICES;
-use crate::bingpai::Bingpai;
+use crate::bingpai::{Bingpai, PlayerRule};
 
-pub(in super::super) fn calculate_replacement_number(bingpai: &Bingpai) -> u8 {
+pub(in super::super) fn calculate_replacement_number<R: PlayerRule>(bingpai: &Bingpai<R>) -> u8 {
     if bingpai.num_required_bingpai_mianzi() < 4 {
         return u8::MAX;
     }
@@ -24,13 +24,14 @@ pub(in super::super) fn calculate_replacement_number(bingpai: &Bingpai) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::FourPlayer;
     use crate::test_utils::FromTileCode;
     use crate::tile::TileCounts;
 
     #[test]
     fn calculate_replacement_number_no_terminals_and_honors() {
         let tile_counts = TileCounts::from_code("23455m345p45678s");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 14);
     }
@@ -38,7 +39,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_without_pair() {
         let tile_counts = TileCounts::from_code("189m12p249s12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 5);
     }
@@ -46,7 +47,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_with_pair() {
         let tile_counts = TileCounts::from_code("119m12p299s12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 4);
     }
@@ -54,7 +55,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_tenpai() {
         let tile_counts = TileCounts::from_code("11m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 1);
     }
@@ -62,7 +63,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_tenpai_13_wait() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 1);
     }
@@ -70,7 +71,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_win() {
         let tile_counts = TileCounts::from_code("119m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 0);
     }
@@ -78,7 +79,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_incomplete_hand() {
         let tile_counts = TileCounts::from_code("19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, u8::MAX);
     }

--- a/src/shisanyao/unnecessary_tiles.rs
+++ b/src/shisanyao/unnecessary_tiles.rs
@@ -3,10 +3,12 @@
 // This file is part of https://github.com/Apricot-S/xiangting
 
 use super::common::YAOJIUPAI_INDICES;
-use crate::bingpai::Bingpai;
+use crate::bingpai::{Bingpai, PlayerRule};
 use crate::tile::TileFlags;
 
-pub(in super::super) fn calculate_unnecessary_tiles(bingpai: &Bingpai) -> (u8, TileFlags) {
+pub(in super::super) fn calculate_unnecessary_tiles<R: PlayerRule>(
+    bingpai: &Bingpai<R>,
+) -> (u8, TileFlags) {
     if bingpai.num_required_bingpai_mianzi() < 4 {
         return (u8::MAX, 0);
     }
@@ -58,13 +60,14 @@ pub(in super::super) fn calculate_unnecessary_tiles(bingpai: &Bingpai) -> (u8, T
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::FourPlayer;
     use crate::test_utils::FromTileCode;
     use crate::tile::{TileCounts, TileFlags};
 
     #[test]
     fn calculate_unnecessary_tiles_no_terminals_and_honors() {
         let tile_counts = TileCounts::from_code("23455m345p45678s");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 14);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("23455m345p45678s"));
@@ -73,7 +76,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_without_pair() {
         let tile_counts = TileCounts::from_code("189m12p249s12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 5);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("8m2p24s"));
@@ -82,7 +85,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_with_pair() {
         let tile_counts = TileCounts::from_code("119m12p299s12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 4);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1m2p29s"));
@@ -91,7 +94,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_tenpai() {
         let tile_counts = TileCounts::from_code("11m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -100,7 +103,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_tenpai_13_wait() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -109,7 +112,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_win() {
         let tile_counts = TileCounts::from_code("119m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 0);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -118,7 +121,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_incomplete_hand() {
         let tile_counts = TileCounts::from_code("19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, u8::MAX);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -30,13 +30,11 @@ mod zipai_map;
 mod zipai_table;
 
 #[cfg(not(feature = "build-file"))]
-pub(super) use necessary_tiles::{calculate_necessary_tiles, calculate_necessary_tiles_3p};
+pub(super) use necessary_tiles::calculate_necessary_tiles;
 #[cfg(not(feature = "build-file"))]
-pub(super) use replacement_number::{
-    calculate_replacement_number, calculate_replacement_number_3p,
-};
+pub(super) use replacement_number::calculate_replacement_number;
 #[cfg(not(feature = "build-file"))]
-pub(super) use unnecessary_tiles::{calculate_unnecessary_tiles, calculate_unnecessary_tiles_3p};
+pub(super) use unnecessary_tiles::calculate_unnecessary_tiles;
 
 #[cfg(feature = "build-map")]
 pub mod core;

--- a/src/standard/necessary_tiles.rs
+++ b/src/standard/necessary_tiles.rs
@@ -123,15 +123,19 @@ pub(in super::super) fn calculate_necessary_tiles<R: PlayerRule>(
 ) -> (u8, TileFlags) {
     let (replacement_number_m, necessary_tiles_m) = if R::IS_THREE_PLAYER {
         let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
+        let packed_rn_m = &WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m];
+        let packed_nt_m = &WANZI_19_NECESSARY_TILES_MAP[hash_m];
         (
-            unpack_replacement_number(&WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m]),
-            unpack_necessary_tiles(&WANZI_19_NECESSARY_TILES_MAP[hash_m]),
+            unpack_replacement_number(packed_rn_m),
+            unpack_necessary_tiles(packed_nt_m),
         )
     } else {
         let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
+        let packed_rn_m = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m];
+        let packed_nt_m = &SHUPAI_NECESSARY_TILES_MAP[hash_m];
         (
-            unpack_replacement_number(&SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m]),
-            unpack_necessary_tiles(&SHUPAI_NECESSARY_TILES_MAP[hash_m]),
+            unpack_replacement_number(packed_rn_m),
+            unpack_necessary_tiles(packed_nt_m),
         )
     };
 

--- a/src/standard/necessary_tiles.rs
+++ b/src/standard/necessary_tiles.rs
@@ -8,7 +8,7 @@ use super::shupai_map::{SHUPAI_NECESSARY_TILES_MAP, SHUPAI_REPLACEMENT_NUMBER_MA
 use super::unpack::{unpack_necessary_tiles, unpack_replacement_number};
 use super::wanzi_19_map::{WANZI_19_NECESSARY_TILES_MAP, WANZI_19_REPLACEMENT_NUMBER_MAP};
 use super::zipai_map::{ZIPAI_NECESSARY_TILES_MAP, ZIPAI_REPLACEMENT_NUMBER_MAP};
-use crate::bingpai::{Bingpai, Bingpai3p};
+use crate::bingpai::{Bingpai, PlayerRule};
 use crate::tile::TileFlags;
 
 fn update_dp(lhs: &mut Entry, rhs: &Entry) {
@@ -118,77 +118,37 @@ fn update_dp_final(lhs: &mut Entry, rhs: &Entry) {
     }
 }
 
-pub(in super::super) fn calculate_necessary_tiles(bingpai: &Bingpai) -> (u8, TileFlags) {
-    let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
+pub(in super::super) fn calculate_necessary_tiles<R: PlayerRule>(
+    bingpai: &Bingpai<R>,
+) -> (u8, TileFlags) {
+    let (replacement_number_m, necessary_tiles_m) = if R::IS_THREE_PLAYER {
+        let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
+        (
+            unpack_replacement_number(&WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m]),
+            unpack_necessary_tiles(&WANZI_19_NECESSARY_TILES_MAP[hash_m]),
+        )
+    } else {
+        let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
+        (
+            unpack_replacement_number(&SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m]),
+            unpack_necessary_tiles(&SHUPAI_NECESSARY_TILES_MAP[hash_m]),
+        )
+    };
+
     let hash_p = hash_shupai(&bingpai.tile_counts()[9..18]);
     let hash_s = hash_shupai(&bingpai.tile_counts()[18..27]);
     let hash_z = hash_zipai(&bingpai.tile_counts()[27..34]);
 
-    let packed_rn_m = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m];
     let packed_rn_p = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_p];
     let packed_rn_s = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_s];
     let packed_rn_z = &ZIPAI_REPLACEMENT_NUMBER_MAP[hash_z];
-    let packed_nt_m = &SHUPAI_NECESSARY_TILES_MAP[hash_m];
     let packed_nt_p = &SHUPAI_NECESSARY_TILES_MAP[hash_p];
     let packed_nt_s = &SHUPAI_NECESSARY_TILES_MAP[hash_s];
     let packed_nt_z = &ZIPAI_NECESSARY_TILES_MAP[hash_z];
 
-    let replacement_number_m = unpack_replacement_number(packed_rn_m);
     let replacement_number_p = unpack_replacement_number(packed_rn_p);
     let replacement_number_s = unpack_replacement_number(packed_rn_s);
     let replacement_number_z = unpack_replacement_number(packed_rn_z);
-    let necessary_tiles_m = unpack_necessary_tiles(packed_nt_m);
-    let necessary_tiles_p = unpack_necessary_tiles(packed_nt_p);
-    let necessary_tiles_s = unpack_necessary_tiles(packed_nt_s);
-    let necessary_tiles_z = unpack_necessary_tiles(packed_nt_z);
-
-    let (mut entry0, entry1, entry2, entry3) = (
-        Entry {
-            numbers: replacement_number_m,
-            tiles: necessary_tiles_m.map(|t| t as TileFlags),
-        },
-        Entry {
-            numbers: replacement_number_p,
-            tiles: necessary_tiles_p.map(|t| (t as TileFlags) << 9),
-        },
-        Entry {
-            numbers: replacement_number_s,
-            tiles: necessary_tiles_s.map(|t| (t as TileFlags) << 18),
-        },
-        Entry {
-            numbers: replacement_number_z,
-            tiles: necessary_tiles_z.map(|t| (t as TileFlags) << 27),
-        },
-    );
-
-    update_dp(&mut entry0, &entry1);
-    update_dp(&mut entry0, &entry2);
-    update_dp_final(&mut entry0, &entry3);
-
-    let n = 5 + bingpai.num_required_bingpai_mianzi() as usize;
-    (entry0.numbers[n] as u8, entry0.tiles[n])
-}
-
-pub(in super::super) fn calculate_necessary_tiles_3p(bingpai: &Bingpai3p) -> (u8, TileFlags) {
-    let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
-    let hash_p = hash_shupai(&bingpai.tile_counts()[9..18]);
-    let hash_s = hash_shupai(&bingpai.tile_counts()[18..27]);
-    let hash_z = hash_zipai(&bingpai.tile_counts()[27..34]);
-
-    let packed_rn_m = &WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m];
-    let packed_rn_p = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_p];
-    let packed_rn_s = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_s];
-    let packed_rn_z = &ZIPAI_REPLACEMENT_NUMBER_MAP[hash_z];
-    let packed_nt_m = &WANZI_19_NECESSARY_TILES_MAP[hash_m];
-    let packed_nt_p = &SHUPAI_NECESSARY_TILES_MAP[hash_p];
-    let packed_nt_s = &SHUPAI_NECESSARY_TILES_MAP[hash_s];
-    let packed_nt_z = &ZIPAI_NECESSARY_TILES_MAP[hash_z];
-
-    let replacement_number_m = unpack_replacement_number(packed_rn_m);
-    let replacement_number_p = unpack_replacement_number(packed_rn_p);
-    let replacement_number_s = unpack_replacement_number(packed_rn_s);
-    let replacement_number_z = unpack_replacement_number(packed_rn_z);
-    let necessary_tiles_m = unpack_necessary_tiles(packed_nt_m);
     let necessary_tiles_p = unpack_necessary_tiles(packed_nt_p);
     let necessary_tiles_s = unpack_necessary_tiles(packed_nt_s);
     let necessary_tiles_z = unpack_necessary_tiles(packed_nt_z);
@@ -223,13 +183,14 @@ pub(in super::super) fn calculate_necessary_tiles_3p(bingpai: &Bingpai3p) -> (u8
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::{FourPlayer, ThreePlayer};
     use crate::test_utils::FromTileCode;
     use crate::tile::{TileCounts, TileFlags};
 
     #[test]
     fn calculate_necessary_tiles_shisanyao_13() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 9);
         assert_eq!(
@@ -241,7 +202,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_shisanyao_14() {
         let tile_counts = TileCounts::from_code("119m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 8);
         assert_eq!(
@@ -253,7 +214,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_tenpai() {
         let tile_counts = TileCounts::from_code("123m456p789s1122z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(necessary_tiles, TileFlags::from_code("12z"));
@@ -262,7 +223,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_win() {
         let tile_counts = TileCounts::from_code("123m456p789s11222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 0);
         assert_eq!(necessary_tiles, TileFlags::from_code(""));
@@ -271,7 +232,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_with_meld_exclude() {
         let tile_counts = TileCounts::from_code("123m456p789s2z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(necessary_tiles, TileFlags::from_code("2z"));
@@ -281,7 +242,7 @@ mod tests {
     fn calculate_necessary_tiles_without_pair() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 雀頭がない場合
         let tile_counts = TileCounts::from_code("12389m456p12789s1z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(necessary_tiles, TileFlags::from_code("789m123s1z"));
@@ -291,7 +252,7 @@ mod tests {
     fn calculate_necessary_tiles_too_many_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 搭子過多の場合
         let tile_counts = TileCounts::from_code("12389m456p1289s11z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(necessary_tiles, TileFlags::from_code("7m37s"));
@@ -301,7 +262,7 @@ mod tests {
     fn calculate_necessary_tiles_not_enough_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 搭子不足の場合
         let tile_counts = TileCounts::from_code("133345568m23677z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(necessary_tiles, TileFlags::from_code("247m"));
@@ -310,7 +271,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_triplet_sequence() {
         let tile_counts = TileCounts::from_code("222345p1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 5);
         assert_eq!(necessary_tiles, TileFlags::from_code("1234567z"));
@@ -319,7 +280,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_sequence_isolated_sequence() {
         let tile_counts = TileCounts::from_code("2344456p123456z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 5);
         assert_eq!(necessary_tiles, TileFlags::from_code("1234567p123456z"));
@@ -328,7 +289,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_pair_triplet_sequence() {
         let tile_counts = TileCounts::from_code("11222345p12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 4);
         assert_eq!(necessary_tiles, TileFlags::from_code("1p12345z"));
@@ -337,7 +298,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_pair_sequence_sequence_pair() {
         let tile_counts = TileCounts::from_code("2234556788p123z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(necessary_tiles, TileFlags::from_code("28p123z"));
@@ -347,7 +308,7 @@ mod tests {
     fn calculate_necessary_tiles_prioritize_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/2022/04/17/174206 面子の分け方
         let tile_counts = TileCounts::from_code("133345568s11567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(necessary_tiles, TileFlags::from_code("247s"));
@@ -357,7 +318,7 @@ mod tests {
     fn calculate_necessary_tiles_waiting_for_the_5th_tile_1() {
         // Source: https://blog.kobalab.net/entry/2022/04/17/174206 5枚目の牌を待つ形
         let tile_counts = TileCounts::from_code("1111m123p112233s");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
@@ -369,7 +330,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_waiting_for_the_5th_tile_2() {
         let tile_counts = TileCounts::from_code("1111234444m1111p");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
@@ -382,7 +343,7 @@ mod tests {
     fn calculate_necessary_tiles_waiting_for_the_5th_tile_3() {
         // Source: http://cmj3.web.fc2.com/#syanten
         let tile_counts = TileCounts::from_code("11112222333444z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
@@ -394,7 +355,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_2_isolated_4_tiles_1() {
         let tile_counts = TileCounts::from_code("1111247777m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(necessary_tiles, TileFlags::from_code("34m"));
@@ -403,7 +364,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_2_isolated_4_tiles_2() {
         let tile_counts = TileCounts::from_code("1111247777m1112z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(necessary_tiles, TileFlags::from_code("34m2z"));
@@ -412,7 +373,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_2_isolated_4_tiles_3() {
         let tile_counts = TileCounts::from_code("11114444m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
@@ -424,7 +385,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_2_isolated_4_tiles_4() {
         let tile_counts = TileCounts::from_code("111124m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(necessary_tiles, TileFlags::from_code("34m"));
@@ -433,7 +394,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_2_isolated_4_tiles_5() {
         let tile_counts = TileCounts::from_code("1111444478m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(
@@ -445,7 +406,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_3_isolated_4_tiles() {
         let tile_counts = TileCounts::from_code("1111247777m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(necessary_tiles, TileFlags::from_code("34m"));
@@ -454,7 +415,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_4_honors_1() {
         let tile_counts = TileCounts::from_code("1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
@@ -466,7 +427,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_4_honors_2() {
         let tile_counts = TileCounts::from_code("123m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
@@ -478,7 +439,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_4_honors_3() {
         let tile_counts = TileCounts::from_code("11112222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
@@ -490,7 +451,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_4_honors_4() {
         let tile_counts = TileCounts::from_code("123m11p11112222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(
@@ -502,7 +463,7 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_different_3p_and_4p() {
         let tile_counts = TileCounts::from_code("1111m111122233z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(necessary_tiles, TileFlags::from_code("23m"));
@@ -511,8 +472,8 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_3p_different_3p_and_4p() {
         let tile_counts = TileCounts::from_code("1111m111122233z");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(
             necessary_tiles,
@@ -523,8 +484,8 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_3p_4_19m_1() {
         let tile_counts = TileCounts::from_code("1111m");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
             necessary_tiles,
@@ -535,8 +496,8 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_3p_4_19m_2() {
         let tile_counts = TileCounts::from_code("1111m123p");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
             necessary_tiles,
@@ -547,8 +508,8 @@ mod tests {
     #[test]
     fn calculate_necessary_tiles_3p_4_19m_3() {
         let tile_counts = TileCounts::from_code("11119999m");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, necessary_tiles) = calculate_necessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, necessary_tiles) = calculate_necessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(
             necessary_tiles,

--- a/src/standard/replacement_number.rs
+++ b/src/standard/replacement_number.rs
@@ -61,12 +61,12 @@ fn update_dp_final(lhs: &mut UnpackedNumbers, rhs: &UnpackedNumbers) {
 }
 
 pub(in super::super) fn calculate_replacement_number<R: PlayerRule>(bingpai: &Bingpai<R>) -> u8 {
-    let mut entry0 = if R::IS_THREE_PLAYER {
+    let packed_rn_m = if R::IS_THREE_PLAYER {
         let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
-        unpack_replacement_number(&WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m])
+        &WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m]
     } else {
         let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
-        unpack_replacement_number(&SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m])
+        &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m]
     };
 
     let hash_p = hash_shupai(&bingpai.tile_counts()[9..18]);
@@ -77,6 +77,7 @@ pub(in super::super) fn calculate_replacement_number<R: PlayerRule>(bingpai: &Bi
     let packed_rn_s = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_s];
     let packed_rn_z = &ZIPAI_REPLACEMENT_NUMBER_MAP[hash_z];
 
+    let mut entry0 = unpack_replacement_number(packed_rn_m);
     let entry1 = unpack_replacement_number(packed_rn_p);
     let entry2 = unpack_replacement_number(packed_rn_s);
     let entry3 = unpack_replacement_number(packed_rn_z);

--- a/src/standard/replacement_number.rs
+++ b/src/standard/replacement_number.rs
@@ -7,7 +7,7 @@ use super::shupai_map::SHUPAI_REPLACEMENT_NUMBER_MAP;
 use super::unpack::{UnpackedNumbers, unpack_replacement_number};
 use super::wanzi_19_map::WANZI_19_REPLACEMENT_NUMBER_MAP;
 use super::zipai_map::ZIPAI_REPLACEMENT_NUMBER_MAP;
-use crate::bingpai::{Bingpai, Bingpai3p};
+use crate::bingpai::{Bingpai, PlayerRule};
 use core::cmp::min;
 
 fn update_dp(lhs: &mut UnpackedNumbers, rhs: &UnpackedNumbers) {
@@ -60,41 +60,23 @@ fn update_dp_final(lhs: &mut UnpackedNumbers, rhs: &UnpackedNumbers) {
     }
 }
 
-pub(in super::super) fn calculate_replacement_number(bingpai: &Bingpai) -> u8 {
-    let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
+pub(in super::super) fn calculate_replacement_number<R: PlayerRule>(bingpai: &Bingpai<R>) -> u8 {
+    let mut entry0 = if R::IS_THREE_PLAYER {
+        let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
+        unpack_replacement_number(&WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m])
+    } else {
+        let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
+        unpack_replacement_number(&SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m])
+    };
+
     let hash_p = hash_shupai(&bingpai.tile_counts()[9..18]);
     let hash_s = hash_shupai(&bingpai.tile_counts()[18..27]);
     let hash_z = hash_zipai(&bingpai.tile_counts()[27..34]);
 
-    let packed_rn_m = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m];
     let packed_rn_p = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_p];
     let packed_rn_s = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_s];
     let packed_rn_z = &ZIPAI_REPLACEMENT_NUMBER_MAP[hash_z];
 
-    let mut entry0 = unpack_replacement_number(packed_rn_m);
-    let entry1 = unpack_replacement_number(packed_rn_p);
-    let entry2 = unpack_replacement_number(packed_rn_s);
-    let entry3 = unpack_replacement_number(packed_rn_z);
-
-    update_dp(&mut entry0, &entry1);
-    update_dp(&mut entry0, &entry2);
-    update_dp_final(&mut entry0, &entry3);
-
-    entry0[5 + bingpai.num_required_bingpai_mianzi() as usize] as u8
-}
-
-pub(in super::super) fn calculate_replacement_number_3p(bingpai: &Bingpai3p) -> u8 {
-    let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
-    let hash_p = hash_shupai(&bingpai.tile_counts()[9..18]);
-    let hash_s = hash_shupai(&bingpai.tile_counts()[18..27]);
-    let hash_z = hash_zipai(&bingpai.tile_counts()[27..34]);
-
-    let packed_rn_m = &WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m];
-    let packed_rn_p = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_p];
-    let packed_rn_s = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_s];
-    let packed_rn_z = &ZIPAI_REPLACEMENT_NUMBER_MAP[hash_z];
-
-    let mut entry0 = unpack_replacement_number(packed_rn_m);
     let entry1 = unpack_replacement_number(packed_rn_p);
     let entry2 = unpack_replacement_number(packed_rn_s);
     let entry3 = unpack_replacement_number(packed_rn_z);
@@ -109,13 +91,14 @@ pub(in super::super) fn calculate_replacement_number_3p(bingpai: &Bingpai3p) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::{FourPlayer, ThreePlayer};
     use crate::test_utils::FromTileCode;
     use crate::tile::TileCounts;
 
     #[test]
     fn calculate_replacement_number_shisanyao_13() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 9);
     }
@@ -123,7 +106,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_shisanyao_14() {
         let tile_counts = TileCounts::from_code("119m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 8);
     }
@@ -131,7 +114,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_tenpai() {
         let tile_counts = TileCounts::from_code("123m456p789s1122z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 1);
     }
@@ -139,7 +122,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_win() {
         let tile_counts = TileCounts::from_code("123m456p789s11222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 0);
     }
@@ -147,7 +130,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_with_meld_exclude() {
         let tile_counts = TileCounts::from_code("123m456p789s2z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 1);
     }
@@ -156,7 +139,7 @@ mod tests {
     fn calculate_replacement_number_without_pair() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 雀頭がない場合
         let tile_counts = TileCounts::from_code("12389m456p12789s1z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -165,7 +148,7 @@ mod tests {
     fn calculate_replacement_number_too_many_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 搭子過多の場合
         let tile_counts = TileCounts::from_code("12389m456p1289s11z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -174,7 +157,7 @@ mod tests {
     fn calculate_replacement_number_not_enough_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 搭子不足の場合
         let tile_counts = TileCounts::from_code("133345568m23677z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 3);
     }
@@ -182,7 +165,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_triplet_sequence() {
         let tile_counts = TileCounts::from_code("222345p1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 5);
     }
@@ -190,7 +173,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_sequence_isolated_sequence() {
         let tile_counts = TileCounts::from_code("2344456p123456z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 5);
     }
@@ -198,7 +181,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_pair_triplet_sequence() {
         let tile_counts = TileCounts::from_code("11222345p12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 4);
     }
@@ -206,7 +189,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_pair_sequence_sequence_pair() {
         let tile_counts = TileCounts::from_code("2234556788p123z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 3);
     }
@@ -215,7 +198,7 @@ mod tests {
     fn calculate_replacement_number_prioritize_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/2022/04/17/174206 面子の分け方
         let tile_counts = TileCounts::from_code("133345568s11567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 3);
     }
@@ -224,7 +207,7 @@ mod tests {
     fn calculate_replacement_number_waiting_for_the_5th_tile_1() {
         // Source: https://blog.kobalab.net/entry/2022/04/17/174206 5枚目の牌を待つ形
         let tile_counts = TileCounts::from_code("1111m123p112233s");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -232,7 +215,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_waiting_for_the_5th_tile_2() {
         let tile_counts = TileCounts::from_code("1111234444m1111p");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -241,7 +224,7 @@ mod tests {
     fn calculate_replacement_number_waiting_for_the_5th_tile_3() {
         // Source: http://cmj3.web.fc2.com/#syanten
         let tile_counts = TileCounts::from_code("11112222333444z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -249,7 +232,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_2_isolated_4_tiles_1() {
         let tile_counts = TileCounts::from_code("1111247777m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -257,7 +240,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_2_isolated_4_tiles_2() {
         let tile_counts = TileCounts::from_code("1111247777m1112z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -265,7 +248,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_2_isolated_4_tiles_3() {
         let tile_counts = TileCounts::from_code("11114444m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -273,7 +256,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_2_isolated_4_tiles_4() {
         let tile_counts = TileCounts::from_code("111124m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -281,7 +264,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_2_isolated_4_tiles_5() {
         let tile_counts = TileCounts::from_code("1111444478m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 3);
     }
@@ -289,7 +272,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_3_isolated_4_tiles() {
         let tile_counts = TileCounts::from_code("1111247777m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -297,7 +280,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_4_honors_1() {
         let tile_counts = TileCounts::from_code("1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -305,7 +288,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_4_honors_2() {
         let tile_counts = TileCounts::from_code("123m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -313,7 +296,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_4_honors_3() {
         let tile_counts = TileCounts::from_code("11112222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -321,7 +304,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_4_honors_4() {
         let tile_counts = TileCounts::from_code("123m11p11112222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 3);
     }
@@ -329,7 +312,7 @@ mod tests {
     #[test]
     fn calculate_replacement_number_different_3p_and_4p() {
         let tile_counts = TileCounts::from_code("1111m111122233z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
@@ -337,32 +320,32 @@ mod tests {
     #[test]
     fn calculate_replacement_number_3p_different_3p_and_4p() {
         let tile_counts = TileCounts::from_code("1111m111122233z");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let replacement_number = calculate_replacement_number_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 3);
     }
 
     #[test]
     fn calculate_replacement_number_3p_4_19m_1() {
         let tile_counts = TileCounts::from_code("1111m");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let replacement_number = calculate_replacement_number_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
 
     #[test]
     fn calculate_replacement_number_3p_4_19m_2() {
         let tile_counts = TileCounts::from_code("1111m123p");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let replacement_number = calculate_replacement_number_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
 
     #[test]
     fn calculate_replacement_number_3p_4_19m_3() {
         let tile_counts = TileCounts::from_code("11119999m");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let replacement_number = calculate_replacement_number_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let replacement_number = calculate_replacement_number(&bingpai);
         assert_eq!(replacement_number, 2);
     }
 }

--- a/src/standard/unnecessary_tiles.rs
+++ b/src/standard/unnecessary_tiles.rs
@@ -8,7 +8,7 @@ use super::shupai_map::{SHUPAI_REPLACEMENT_NUMBER_MAP, SHUPAI_UNNECESSARY_TILES_
 use super::unpack::{unpack_replacement_number, unpack_unnecessary_tiles};
 use super::wanzi_19_map::{WANZI_19_REPLACEMENT_NUMBER_MAP, WANZI_19_UNNECESSARY_TILES_MAP};
 use super::zipai_map::{ZIPAI_REPLACEMENT_NUMBER_MAP, ZIPAI_UNNECESSARY_TILES_MAP};
-use crate::bingpai::{Bingpai, Bingpai3p};
+use crate::bingpai::{Bingpai, PlayerRule};
 use crate::tile::TileFlags;
 
 fn update_dp(lhs: &mut Entry, rhs: &Entry) {
@@ -135,77 +135,37 @@ fn update_dp_final(lhs: &mut Entry, rhs: &Entry) {
     }
 }
 
-pub(in super::super) fn calculate_unnecessary_tiles(bingpai: &Bingpai) -> (u8, TileFlags) {
-    let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
+pub(in super::super) fn calculate_unnecessary_tiles<R: PlayerRule>(
+    bingpai: &Bingpai<R>,
+) -> (u8, TileFlags) {
+    let (replacement_number_m, unnecessary_tiles_m) = if R::IS_THREE_PLAYER {
+        let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
+        (
+            unpack_replacement_number(&WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m]),
+            unpack_unnecessary_tiles(&WANZI_19_UNNECESSARY_TILES_MAP[hash_m]),
+        )
+    } else {
+        let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
+        (
+            unpack_replacement_number(&SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m]),
+            unpack_unnecessary_tiles(&SHUPAI_UNNECESSARY_TILES_MAP[hash_m]),
+        )
+    };
+
     let hash_p = hash_shupai(&bingpai.tile_counts()[9..18]);
     let hash_s = hash_shupai(&bingpai.tile_counts()[18..27]);
     let hash_z = hash_zipai(&bingpai.tile_counts()[27..34]);
 
-    let packed_rn_m = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m];
     let packed_rn_p = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_p];
     let packed_rn_s = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_s];
     let packed_rn_z = &ZIPAI_REPLACEMENT_NUMBER_MAP[hash_z];
-    let packed_ut_m = &SHUPAI_UNNECESSARY_TILES_MAP[hash_m];
     let packed_ut_p = &SHUPAI_UNNECESSARY_TILES_MAP[hash_p];
     let packed_ut_s = &SHUPAI_UNNECESSARY_TILES_MAP[hash_s];
     let packed_ut_z = &ZIPAI_UNNECESSARY_TILES_MAP[hash_z];
 
-    let replacement_number_m = unpack_replacement_number(packed_rn_m);
     let replacement_number_p = unpack_replacement_number(packed_rn_p);
     let replacement_number_s = unpack_replacement_number(packed_rn_s);
     let replacement_number_z = unpack_replacement_number(packed_rn_z);
-    let unnecessary_tiles_m = unpack_unnecessary_tiles(packed_ut_m);
-    let unnecessary_tiles_p = unpack_unnecessary_tiles(packed_ut_p);
-    let unnecessary_tiles_s = unpack_unnecessary_tiles(packed_ut_s);
-    let unnecessary_tiles_z = unpack_unnecessary_tiles(packed_ut_z);
-
-    let (mut entry0, entry1, entry2, entry3) = (
-        Entry {
-            numbers: replacement_number_m,
-            tiles: unnecessary_tiles_m.map(|t| t as TileFlags),
-        },
-        Entry {
-            numbers: replacement_number_p,
-            tiles: unnecessary_tiles_p.map(|t| (t as TileFlags) << 9),
-        },
-        Entry {
-            numbers: replacement_number_s,
-            tiles: unnecessary_tiles_s.map(|t| (t as TileFlags) << 18),
-        },
-        Entry {
-            numbers: replacement_number_z,
-            tiles: unnecessary_tiles_z.map(|t| (t as TileFlags) << 27),
-        },
-    );
-
-    update_dp(&mut entry0, &entry1);
-    update_dp(&mut entry0, &entry2);
-    update_dp_final(&mut entry0, &entry3);
-
-    let n = 5 + bingpai.num_required_bingpai_mianzi() as usize;
-    (entry0.numbers[n] as u8, entry0.tiles[n])
-}
-
-pub(in super::super) fn calculate_unnecessary_tiles_3p(bingpai: &Bingpai3p) -> (u8, TileFlags) {
-    let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
-    let hash_p = hash_shupai(&bingpai.tile_counts()[9..18]);
-    let hash_s = hash_shupai(&bingpai.tile_counts()[18..27]);
-    let hash_z = hash_zipai(&bingpai.tile_counts()[27..34]);
-
-    let packed_rn_m = &WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m];
-    let packed_rn_p = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_p];
-    let packed_rn_s = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_s];
-    let packed_rn_z = &ZIPAI_REPLACEMENT_NUMBER_MAP[hash_z];
-    let packed_ut_m = &WANZI_19_UNNECESSARY_TILES_MAP[hash_m];
-    let packed_ut_p = &SHUPAI_UNNECESSARY_TILES_MAP[hash_p];
-    let packed_ut_s = &SHUPAI_UNNECESSARY_TILES_MAP[hash_s];
-    let packed_ut_z = &ZIPAI_UNNECESSARY_TILES_MAP[hash_z];
-
-    let replacement_number_m = unpack_replacement_number(packed_rn_m);
-    let replacement_number_p = unpack_replacement_number(packed_rn_p);
-    let replacement_number_s = unpack_replacement_number(packed_rn_s);
-    let replacement_number_z = unpack_replacement_number(packed_rn_z);
-    let unnecessary_tiles_m = unpack_unnecessary_tiles(packed_ut_m);
     let unnecessary_tiles_p = unpack_unnecessary_tiles(packed_ut_p);
     let unnecessary_tiles_s = unpack_unnecessary_tiles(packed_ut_s);
     let unnecessary_tiles_z = unpack_unnecessary_tiles(packed_ut_z);
@@ -240,13 +200,14 @@ pub(in super::super) fn calculate_unnecessary_tiles_3p(bingpai: &Bingpai3p) -> (
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bingpai::{FourPlayer, ThreePlayer};
     use crate::test_utils::FromTileCode;
     use crate::tile::{TileCounts, TileFlags};
 
     #[test]
     fn calculate_unnecessary_tiles_shisanyao_13() {
         let tile_counts = TileCounts::from_code("19m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 9);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("19m19p19s1234567z"));
@@ -255,7 +216,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_shisanyao_14() {
         let tile_counts = TileCounts::from_code("119m19p19s1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 8);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("9m19p19s1234567z"));
@@ -264,7 +225,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_tenpai() {
         let tile_counts = TileCounts::from_code("123m456p789s1122z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -273,7 +234,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_win() {
         let tile_counts = TileCounts::from_code("123m456p789s11222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 0);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -282,7 +243,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_with_meld_exclude() {
         let tile_counts = TileCounts::from_code("123m456p789s2z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 1);
         assert_eq!(unnecessary_tiles, TileFlags::from_code(""));
@@ -292,7 +253,7 @@ mod tests {
     fn calculate_unnecessary_tiles_without_pair() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 雀頭がない場合
         let tile_counts = TileCounts::from_code("12389m456p12789s1z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("89m12s1z"));
@@ -302,7 +263,7 @@ mod tests {
     fn calculate_unnecessary_tiles_too_many_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 搭子過多の場合
         let tile_counts = TileCounts::from_code("12389m456p1289s11z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("89m1289s"));
@@ -312,7 +273,7 @@ mod tests {
     fn calculate_unnecessary_tiles_not_enough_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/20151216/1450191666 搭子不足の場合
         let tile_counts = TileCounts::from_code("133345568m23677z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("236z"));
@@ -321,7 +282,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_triplet_sequence() {
         let tile_counts = TileCounts::from_code("222345p1234567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 5);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1234567z"));
@@ -330,7 +291,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_sequence_isolated_sequence() {
         let tile_counts = TileCounts::from_code("2344456p123456z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 5);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("4p123456z"));
@@ -339,7 +300,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_pair_triplet_sequence() {
         let tile_counts = TileCounts::from_code("11222345p12345z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 4);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("12345z"));
@@ -348,7 +309,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_pair_sequence_sequence_pair() {
         let tile_counts = TileCounts::from_code("2234556788p123z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("123z"));
@@ -358,7 +319,7 @@ mod tests {
     fn calculate_unnecessary_tiles_prioritize_meld_candidates() {
         // Source: https://blog.kobalab.net/entry/2022/04/17/174206 面子の分け方
         let tile_counts = TileCounts::from_code("133345568s11567z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("567z"));
@@ -368,7 +329,7 @@ mod tests {
     fn calculate_unnecessary_tiles_waiting_for_the_5th_tile_1() {
         // Source: https://blog.kobalab.net/entry/2022/04/17/174206 5枚目の牌を待つ形
         let tile_counts = TileCounts::from_code("1111m123p112233s");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1m"));
@@ -377,7 +338,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_waiting_for_the_5th_tile_2() {
         let tile_counts = TileCounts::from_code("1111234444m1111p");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("14m1p"));
@@ -387,7 +348,7 @@ mod tests {
     fn calculate_unnecessary_tiles_waiting_for_the_5th_tile_3() {
         // Source: http://cmj3.web.fc2.com/#syanten
         let tile_counts = TileCounts::from_code("11112222333444z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("12z"));
@@ -396,7 +357,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_2_isolated_4_tiles_1() {
         let tile_counts = TileCounts::from_code("1111247777m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("7m"));
@@ -405,7 +366,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_2_isolated_4_tiles_2() {
         let tile_counts = TileCounts::from_code("1111247777m1112z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("147m2z"));
@@ -414,7 +375,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_2_isolated_4_tiles_3() {
         let tile_counts = TileCounts::from_code("11114444m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("14m"));
@@ -423,7 +384,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_2_isolated_4_tiles_4() {
         let tile_counts = TileCounts::from_code("111124m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1z"));
@@ -432,7 +393,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_2_isolated_4_tiles_5() {
         let tile_counts = TileCounts::from_code("1111444478m");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1478m"));
@@ -441,7 +402,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_3_isolated_4_tiles() {
         let tile_counts = TileCounts::from_code("1111247777m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("7m1z"));
@@ -450,7 +411,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_4_honors_1() {
         let tile_counts = TileCounts::from_code("1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1z"));
@@ -459,7 +420,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_4_honors_2() {
         let tile_counts = TileCounts::from_code("123m1111z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1z"));
@@ -468,7 +429,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_4_honors_3() {
         let tile_counts = TileCounts::from_code("11112222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("12z"));
@@ -477,7 +438,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_4_honors_4() {
         let tile_counts = TileCounts::from_code("123m11p11112222z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("12z"));
@@ -486,7 +447,7 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_different_3p_and_4p() {
         let tile_counts = TileCounts::from_code("1111m111122233z");
-        let bingpai = Bingpai::new(&tile_counts).unwrap();
+        let bingpai = Bingpai::<FourPlayer>::new(&tile_counts).unwrap();
         let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1z1z"));
@@ -495,8 +456,8 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_3p_different_3p_and_4p() {
         let tile_counts = TileCounts::from_code("1111m111122233z");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 3);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1m1z"));
     }
@@ -504,8 +465,8 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_3p_4_19m_1() {
         let tile_counts = TileCounts::from_code("1111m");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1m"));
     }
@@ -513,8 +474,8 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_3p_4_19m_2() {
         let tile_counts = TileCounts::from_code("1111m123p");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("1m"));
     }
@@ -522,8 +483,8 @@ mod tests {
     #[test]
     fn calculate_unnecessary_tiles_3p_4_19m_3() {
         let tile_counts = TileCounts::from_code("11119999m");
-        let bingpai = Bingpai3p::new(&tile_counts).unwrap();
-        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles_3p(&bingpai);
+        let bingpai = Bingpai::<ThreePlayer>::new(&tile_counts).unwrap();
+        let (replacement_number, unnecessary_tiles) = calculate_unnecessary_tiles(&bingpai);
         assert_eq!(replacement_number, 2);
         assert_eq!(unnecessary_tiles, TileFlags::from_code("19m"));
     }

--- a/src/standard/unnecessary_tiles.rs
+++ b/src/standard/unnecessary_tiles.rs
@@ -140,15 +140,19 @@ pub(in super::super) fn calculate_unnecessary_tiles<R: PlayerRule>(
 ) -> (u8, TileFlags) {
     let (replacement_number_m, unnecessary_tiles_m) = if R::IS_THREE_PLAYER {
         let hash_m = hash_19m(&bingpai.tile_counts()[0..9]);
+        let packed_rn_m = &WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m];
+        let packed_ut_m = &WANZI_19_UNNECESSARY_TILES_MAP[hash_m];
         (
-            unpack_replacement_number(&WANZI_19_REPLACEMENT_NUMBER_MAP[hash_m]),
-            unpack_unnecessary_tiles(&WANZI_19_UNNECESSARY_TILES_MAP[hash_m]),
+            unpack_replacement_number(packed_rn_m),
+            unpack_unnecessary_tiles(packed_ut_m),
         )
     } else {
         let hash_m = hash_shupai(&bingpai.tile_counts()[0..9]);
+        let packed_rn_m = &SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m];
+        let packed_ut_m = &SHUPAI_UNNECESSARY_TILES_MAP[hash_m];
         (
-            unpack_replacement_number(&SHUPAI_REPLACEMENT_NUMBER_MAP[hash_m]),
-            unpack_unnecessary_tiles(&SHUPAI_UNNECESSARY_TILES_MAP[hash_m]),
+            unpack_replacement_number(packed_rn_m),
+            unpack_unnecessary_tiles(packed_ut_m),
         )
     };
 

--- a/src/unnecessary_tiles.rs
+++ b/src/unnecessary_tiles.rs
@@ -5,7 +5,7 @@
 use super::qiduizi;
 use super::shisanyao;
 use super::standard;
-use crate::bingpai::{Bingpai, Bingpai3p, BingpaiError};
+use crate::bingpai::{Bingpai, BingpaiError, FourPlayer, PlayerRule, ThreePlayer};
 use crate::config::PlayerCount;
 use crate::tile::{TileCounts, TileFlags};
 use core::cmp::Ordering;
@@ -75,15 +75,13 @@ pub fn calculate_unnecessary_tiles(
     player_count: PlayerCount,
 ) -> Result<(u8, TileFlags), BingpaiError> {
     match player_count {
-        PlayerCount::Four => calculate_unnecessary_tiles_4p(bingpai),
-        PlayerCount::Three => calculate_unnecessary_tiles_3p(bingpai),
+        PlayerCount::Four => calculate_for::<FourPlayer>(bingpai),
+        PlayerCount::Three => calculate_for::<ThreePlayer>(bingpai),
     }
 }
 
-fn calculate_unnecessary_tiles_4p(
-    tile_counts: &TileCounts,
-) -> Result<(u8, TileFlags), BingpaiError> {
-    let bingpai = Bingpai::new(tile_counts)?;
+fn calculate_for<R: PlayerRule>(tile_counts: &TileCounts) -> Result<(u8, TileFlags), BingpaiError> {
+    let bingpai = Bingpai::<R>::new(tile_counts)?;
 
     let (mut replacement_number, mut unnecessary_tiles) =
         standard::calculate_unnecessary_tiles(&bingpai);
@@ -97,39 +95,6 @@ fn calculate_unnecessary_tiles_4p(
         Ordering::Equal => unnecessary_tiles |= u1,
         Ordering::Greater => (),
     }
-
-    let (r2, u2) = shisanyao::calculate_unnecessary_tiles(&bingpai);
-    match r2.cmp(&replacement_number) {
-        Ordering::Less => {
-            replacement_number = r2;
-            unnecessary_tiles = u2;
-        }
-        Ordering::Equal => unnecessary_tiles |= u2,
-        Ordering::Greater => (),
-    }
-
-    Ok((replacement_number, unnecessary_tiles))
-}
-
-fn calculate_unnecessary_tiles_3p(
-    tile_counts: &TileCounts,
-) -> Result<(u8, TileFlags), BingpaiError> {
-    let bingpai_3p = Bingpai3p::new(tile_counts)?;
-
-    let (mut replacement_number, mut unnecessary_tiles) =
-        standard::calculate_unnecessary_tiles_3p(&bingpai_3p);
-
-    let (r1, u1) = qiduizi::calculate_unnecessary_tiles_3p(&bingpai_3p);
-    match r1.cmp(&replacement_number) {
-        Ordering::Less => {
-            replacement_number = r1;
-            unnecessary_tiles = u1;
-        }
-        Ordering::Equal => unnecessary_tiles |= u1,
-        Ordering::Greater => (),
-    }
-
-    let bingpai = bingpai_3p.into();
 
     let (r2, u2) = shisanyao::calculate_unnecessary_tiles(&bingpai);
     match r2.cmp(&replacement_number) {


### PR DESCRIPTION
計算速度が悪化しているが、まだ高速な方ではあるため設計改善を優先する。

ベンチマーク結果 (各 2 回測定)

変更前

```
variant/shanten_number/normal
                        time:   [64.747 ns 64.931 ns 65.127 ns]
                        change: [−0.9484% −0.3232% +0.2562%] (p = 0.28 > 0.05)

variant/shanten_number/normal
                        time:   [65.395 ns 65.565 ns 65.743 ns]
                        change: [+4.8114% +6.5989% +8.9331%] (p = 0.00 < 0.05)
```

変更後

```
variant/shanten_number/normal
                        time:   [72.313 ns 72.581 ns 72.859 ns]
                        change: [+3.3122% +5.6284% +7.4184%] (p = 0.00 < 0.05)
                        Performance has regressed.

variant/shanten_number/normal
                        time:   [71.349 ns 71.727 ns 72.157 ns]
                        change: [−1.8446% −1.0412% −0.2721%] (p = 0.01 < 0.05)
                        Change within noise threshold.
```

## Codex (5.6 Sol 中) による調査結果

原因は、`PhantomData` やコンパイル時分岐ではなく、ジェネリック化によってインライン化の判断が変わったことです。

同じ Rust 1.97.1、`codegen-units=1` で生成コードを比較すると、ホット関数は次のように変化していました。

| | 変更前 | 変更後 |
|---|---:|---:|
| 概算命令数 | 271 | 433 |
| スタック使用量 | 216 bytes | 280 bytes |
| 七対子・国士の計算 | 関数呼び出し | 呼び出し元へインライン化 |

変更前は、通常形の計算後に七対子と国士無双を別関数として呼び出していました。

```text
calculate_replacement_number_4p
 ├─ standard
 ├─ call qiduizi
 └─ call shisanyao
```

変更後はジェネリック関数が利用側でモノモーフィゼーションされ、七対子と国士無双の本体まで `calculate_for::<FourPlayer>` にインライン化されています。

```text
calculate_for::<FourPlayer>
 ├─ standard
 ├─ qiduizi 本体
 └─ shisanyao 本体
```

その結果、ホット関数が約60%大きくなり、スタック使用量も増えています。命令キャッシュ、CPUフロントエンド、レジスタ圧迫・スピルなどの影響で、今回のような小さな関数では5〜10%程度の低下が起こり得ます。

一方、4人用生成コードには以下が存在しないことも確認しました。

- `IS_THREE_PLAYER` の実行時分岐
- `hash_19m`
- `WANZI_19_*`
- 動的ディスパッチ
- `PhantomData` に由来する処理

したがって、「コンパイル時分岐が消えなかった」のではありません。

手元でコミットごとに再測定しても、低下箇所はジェネリック統合コミット `98c3855` に一致しました。

- 統合前 `f6a9884`: 約69.4 ns
- 統合直後 `98c3855`: 約77.6 ns
- 現在: 約76.0 ns

絶対値は実行順序や温度の影響を受けますが、低下箇所は明確でした。

設計を維持した改善案としては、七対子・国士の内部に非ジェネリックなコア関数を設ける方法が有力です。

```rust
fn calculate_replacement_number<R: PlayerRule>(
    bingpai: &Bingpai<R>,
) -> u8 {
    calculate_replacement_number_core(
        bingpai.tile_counts(),
        bingpai.num_required_bingpai_mianzi(),
    )
}

#[inline(never)]
fn calculate_replacement_number_core(
    tile_counts: &TileCounts,
    num_required_mianzi: u8,
) -> u8 {
    // 現在の計算本体
}
```

単にジェネリック関数へ `#[inline(never)]` を付けるだけでは、`&Bingpai<R>` の受け渡し方まで変わって逆に悪化する可能性があります。薄いジェネリックラッパーから、必要な値だけを非ジェネリック関数へ渡す形がよさそうです。

結論として、今回の低下はゼロコスト抽象化そのもののコストではなく、抽象化によって最適化・インライン化の境界が変わった副作用です。設計変更を維持する判断は妥当だと思います。
